### PR TITLE
ci: push container image to ghcr

### DIFF
--- a/.github/workflows/release-dockerhub.yml
+++ b/.github/workflows/release-dockerhub.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
     steps:
       # GitHub Actions do not automatically checkout your projects. If you need the code
       # you need to check it out.
@@ -23,6 +27,7 @@ jobs:
         id: prep
         run: |
           DOCKER_IMAGE=ray1ex/asgi-webdav
+          GHCR_IMAGR=rexzhang/asgi-webdav
           VERSION=edge
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -30,9 +35,9 @@ jobs:
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="${DOCKER_IMAGE}:${VERSION},${GHCR_IMAGE}:${VERSION}"
           if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest,${GHCR_IMAGE}:latest"
           fi
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
@@ -51,6 +56,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build


### PR DESCRIPTION
参考：
https://docs.github.com/zh/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions
https://docs.github.com/zh/actions/publishing-packages/publishing-docker-images

既然加了ghcr，这个文件名就不太合适了，但是我就不改工作流文件名了，请您修改