### PR TITLE
feat(container): config in-container host,port and configfile by env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     # LDAP client's depends ---
     && apk add --no-cache libsasl libldap \
     # create non-root user ---
-    && apk add --no-cache shadow \
+    && apk add --no-cache shadow su-exec\
     && addgroup -S -g $GID runner \
     && adduser -S -D -G runner -u $UID -s /bin/sh runner \
     # support timezone ---
@@ -45,7 +45,8 @@ WORKDIR /app
 VOLUME /data
 EXPOSE 8000
 
-ENTRYPOINT /app/entrypoint.sh
+ENTRYPOINT [ "/app/entrypoint.sh" ]
+CMD [ "asgi_webdav" ]
 
 LABEL org.opencontainers.image.title="ASGI WebDAV Server"
 LABEL org.opencontainers.image.authors="Rex Zhang"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ARG ENV
 ENV TZ="Asia/Shanghai"
 ENV UID=1000
 ENV GID=1000
-ENV DEBUG="false"
 ENV WEBDAV_LOGGING_LEVEL="INFO"
 
 RUN if [ "$ENV" = "rex" ]; then echo "Change depends" \
@@ -45,8 +44,7 @@ WORKDIR /app
 VOLUME /data
 EXPOSE 8000
 
-ENTRYPOINT [ "/app/entrypoint.sh" ]
-CMD [ "asgi_webdav" ]
+CMD [ "/app/entrypoint.sh" ]
 
 LABEL org.opencontainers.image.title="ASGI WebDAV Server"
 LABEL org.opencontainers.image.authors="Rex Zhang"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,21 +1,44 @@
 #!/bin/sh
 
-## set non-root user
-usermod -o -u "$UID" runner
-groupmod -o -g "$GID" runner
-
-echo "
-------------------------
-User uid: $(id -u runner)
-User gid: $(id -g runner)
-------------------------
-"
-
-echo "prepare..."
-chown -R runner:runner /data
-
-# run server
-su runner -c "python -m asgi_webdav -H 0.0.0.0 -c /data/webdav.json --logging-no-display-datetime --logging-no-use-colors"
-
 # for dev
-if [ "$DEBUG" = "true" ]; then python; fi
+if [ "$DEBUG" = "true" ]; then exec python; fi
+
+if [ "$1" == "asgi_webdav" ]; then
+
+	## set non-root user
+	usermod -o -u "$UID" runner
+	groupmod -o -g "$GID" runner
+
+	echo "
+	------------------------
+	User uid: $(id -u runner)
+	User gid: $(id -g runner)
+	------------------------
+	"
+
+	echo "prepare..."
+	chown -R runner:runner /data
+
+	if [ -z "$WEBDAV_HOST" ]; then
+		WEBDAV_HOST="0.0.0.0"
+	fi
+
+	if [ -z "$WEBDAV_PORT" ]; then
+		WEBDAV_PORT="8000"
+	fi
+
+	if [ -z "$WEBDAV_CONFIGFILE" ]; then
+		WEBDAV_CONFIGFILE="/data/webdav.json"
+	fi
+
+	exec su-exec runner \
+		python -m asgi_webdav \
+			--host "$WEBDAV_HOST" \
+			--port "$WEBDAV_PORT" \
+			--config "$WEBDAV_CONFIGFILE" \
+			--logging-no-display-datetime \
+			--logging-no-use-colors 
+
+fi
+
+exec $*

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,44 +1,35 @@
 #!/bin/sh
 
-# for dev
-if [ "$DEBUG" = "true" ]; then exec python; fi
+## set non-root user
+usermod -o -u "$UID" runner
+groupmod -o -g "$GID" runner
 
-if [ "$1" == "asgi_webdav" ]; then
+echo "
+------------------------
+User uid: $(id -u runner)
+User gid: $(id -g runner)
+------------------------
+"
 
-	## set non-root user
-	usermod -o -u "$UID" runner
-	groupmod -o -g "$GID" runner
+echo "prepare..."
+chown -R runner:runner /data
 
-	echo "
-	------------------------
-	User uid: $(id -u runner)
-	User gid: $(id -g runner)
-	------------------------
-	"
-
-	echo "prepare..."
-	chown -R runner:runner /data
-
-	if [ -z "$WEBDAV_HOST" ]; then
-		WEBDAV_HOST="0.0.0.0"
-	fi
-
-	if [ -z "$WEBDAV_PORT" ]; then
-		WEBDAV_PORT="8000"
-	fi
-
-	if [ -z "$WEBDAV_CONFIGFILE" ]; then
-		WEBDAV_CONFIGFILE="/data/webdav.json"
-	fi
-
-	exec su-exec runner \
-		python -m asgi_webdav \
-			--host "$WEBDAV_HOST" \
-			--port "$WEBDAV_PORT" \
-			--config "$WEBDAV_CONFIGFILE" \
-			--logging-no-display-datetime \
-			--logging-no-use-colors 
-
+if [ -z "$WEBDAV_HOST" ]; then
+	WEBDAV_HOST="0.0.0.0"
 fi
 
-exec $*
+if [ -z "$WEBDAV_PORT" ]; then
+	WEBDAV_PORT="8000"
+fi
+
+if [ -z "$WEBDAV_CONFIGFILE" ]; then
+	WEBDAV_CONFIGFILE="/data/webdav.json"
+fi
+
+exec su-exec runner \
+	python -m asgi_webdav \
+		--host "$WEBDAV_HOST" \
+		--port "$WEBDAV_PORT" \
+		--config "$WEBDAV_CONFIGFILE" \
+		--logging-no-display-datetime \
+		--logging-no-use-colors 


### PR DESCRIPTION
feat(container): config in-container host,port and configfile by environment variables && improve entrypoint.sh

这里有一个未使用的环境变量 DEBUG 我没有动， 看原来entrypoint 的逻辑是服务器停了之后进入python。
也就是只能 docker run -it  启动，^C 中断服务器，然后才进入python 。 
全文搜索了一下 好像并没有用到。有build_docker_and_test.sh使用DEBUG环境变量， 但是实际没用到后面执行python。  

这里修改任何CMD进程都为pid1了，停了之后容器就退出了，没有后续了。目前将‘DEBUG=true 运行 python’ 放到运行服务器前。

目前有了 exec $* 这个功能可能用途不大了。
![image](https://github.com/rexzhang/asgi-webdav/assets/33248848/a19d151c-181b-4d7d-9c4e-3ecde5e99fa1)
