### PR TITLE
Feature/handle non existing parent

### DIFF
--- a/asgi_webdav/provider/file_system.py
+++ b/asgi_webdav/provider/file_system.py
@@ -398,8 +398,8 @@ class FileSystemProvider(DAVProvider):
         if await aiofiles.ospath.exists(fs_path):
             if await aiofiles.ospath.isdir(fs_path):
                 return 405
-
-            # return 409 # TODO overwrite???? 11. owner_modify..........
+        if not await aiofiles.ospath.isdir(fs_path.parent):
+            return 409
 
         try:
             async with aiofiles.open(fs_path, "wb") as f:

--- a/asgi_webdav/provider/memory.py
+++ b/asgi_webdav/provider/memory.py
@@ -377,6 +377,8 @@ class MemoryProvider(DAVProvider):
                 content += request_data.get("body", b"")
 
             parent_member = self.fs_root.get_member(request.dist_src_path.parent)
+            if not parent_member:
+                return 409
             parent_member.add_file_child(request.dist_src_path.name, content)
             return 201
 

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.2 - 20250423
+
+- Add, handle non-existing parent folder, thanks [SilviaSWR](https://github.com/SilviaSWR)
+
 ## 1.4.1 - 20240626
 
 - Add, config in-container host,port and configfile by env, thanks [bonjour-py](https://github.com/bonjour-py)


### PR DESCRIPTION

# Description

The PUT method in both the Memory and FileSystem providers now checks whether the parent folder exists, returning a 409 Conflict error if it does not.

fixes #63
