### PR TITLE
Implement an LDAP fallback authentication mechanism.

### DIFF
--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -1,10 +1,12 @@
 import asyncio
 import binascii
+import copy
 import hashlib
 import re
 from base64 import b64decode
 from enum import Enum, auto
 from logging import getLogger
+from urllib.parse import parse_qs
 from uuid import uuid4
 
 try:
@@ -164,7 +166,35 @@ class DAVPassword:
 
         return True, None
 
-    async def check_ldap_password(self, password: str) -> tuple[bool, str | None]:
+    async def check_ldap_password_v2(
+        self, username: str, password: str
+    ) -> (bool, str | None):
+        """
+        <ldap>#2#{ldap-uri}#{ldap-params}#{ldap-user}
+        <ldap>#2#ldaps:/your.domain.com#cert_policy=try#uid={username},cn=users,cn=accounts,dc=domain,dc=tld
+        """
+        if bonsai is None or bonsai_exception is None:
+            return False, "Please install LDAP module: pip install -U ASGIWebDAV[ldap]"
+
+        cert_policy = parse_qs(self.data[3]).get("cert_policy", ["try"])[0]
+        bind_dn = self.data[4].format(username=username)
+
+        client = bonsai.LDAPClient(self.data[2])
+        client.set_credentials("SIMPLE", user=bind_dn, password=password)
+        client.set_cert_policy(cert_policy)
+
+        try:
+            conn = await client.connect(is_async=True)
+            conn.close()
+
+        except bonsai_exception.AuthenticationError:
+            return False, "LDAP Authentication Error"
+        except bonsai_exception.AuthMethodNotSupported:
+            return False, "LDAP auth method not supported"
+
+        return True, None
+
+    async def check_ldap_password(self, username:str, password: str) -> tuple[bool, str | None]:
         """
         <ldap>#{version}#{ldap-uri}#{ldap-extra-info}#{ldap-user}
         """
@@ -173,6 +203,10 @@ class DAVPassword:
             case "1":
                 return await self.check_ldap_password_v1(
                     username=self.data[4], password=password
+                )
+            case "2":
+                return await self.check_ldap_password_v2(
+                    username=username, password=password
                 )
 
             case _:
@@ -267,7 +301,7 @@ class HTTPBasicAuth(HTTPAuthAbc):
                 valid, message = pw_obj.check_digest_password(user.username, password)
 
             case DAVPasswordType.LDAP:
-                valid, message = await pw_obj.check_ldap_password(password)
+                valid, message = await pw_obj.check_ldap_password(user.username, password)
 
             case _:
                 valid, message = False, pw_obj.message
@@ -541,7 +575,14 @@ class DAVAuth:
 
             user = self.user_mapping.get(username)
             if user is None:
-                return None, "no permission"  # TODO
+                # The user does not exist in the data file, but may be in the LDAP fallback.
+                # Copy the data to avoid overwriting the template for future sessions.
+                fallback = self.user_mapping.get("*ldap")
+                if fallback is None:
+                    # A fallback is not configured.
+                    return None, "no permission"
+                user = copy.copy(fallback)
+                user.username = username
 
             if not await self.http_basic_auth.check_password(user, request_password):
                 return None, "no permission"  # TODO

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 1.4.2 - 20250424
+
+- Allow authenticating any user from LDAP server, thanks [PIC](https://www.pic.es)
+
 ## 1.4.2 - 20250424
 
 - Fix, ensure expected HTTP response header is included in responses, thanks [SilviaSWR](https://github.com/SilviaSWR)

--- a/docs/guide/protect-your-password-in-the-config.en.md
+++ b/docs/guide/protect-your-password-in-the-config.en.md
@@ -18,6 +18,11 @@
             "username": "user-ldap",
             "password": "<ldap>#1#ldaps://your.ldap.server.com#SIMPLE#uid=user-ldap,cn=users,dc=your.ldap.server.com",
             "permissions": ["+^/$"]
+        },
+        {
+            "username": "*",
+            "password": "<ldap>#2#ldaps://your.ldap.server.com#cert_policy=try#uid={username},cn=users,dc=your.ldap.server.com",
+            "permissions": ["+^/$"]
         }
     ]
 }
@@ -113,6 +118,45 @@ Example:
 Example:
 
 `uid=you-name,cn=users,dc=ldap,dc=server,dc=com`
+
+## LDAP fallback
+Use `"*"` as `username` to use it as fallback for any user not explicitly set in the configuration file.
+`password`'s format is `"<ldap_users>#ldaps://{ldap-uri}#{params}#{user-dn-pattern}"`.
+
+### {ldap-uri}
+
+Example:
+
+`ldap://your.ldap.server.com` `ldaps://your.tls.ldap.server.com`
+
+#### Ref
+
+- [Official Website](https://ldap.com/ldap-urls/)
+- [RFC4516](https://docs.ldap.com/specs/rfc4516.txt)
+
+### {params}
+
+This is a query string specifying additional optional settings. Only one is supported as of now:
+
+`cert_policy` indicates the policy about server verification. The allowed values are:
+
+* `try` or `demand`: The server cert will be verified, and if it fais, an error will be raised. This is the default.
+* `never` or `allow`: The server cert will be used without any verification.
+
+Example:
+
+`cert_policy=try`
+
+#### Ref
+
+- [RFC1866](https://datatracker.ietf.org/doc/html/rfc1866)
+
+
+### {user-dn-pattern}
+
+Specify the user DN pattern, with a `username` substitution field. Example:
+
+`uid={username},cn=users,dc=ldap,dc=server,dc=com`
 
 ## Compatibility
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -109,6 +109,12 @@ def test_dev_password_class():
     )
     assert pw_obj.type == DAVPasswordType.LDAP
 
+    # ldap fallback
+    pw_obj = DAVPassword(
+        "<ldap>#2#ldaps://your.domain.com#cert_policy=try#uid={username},cn=users,dc=domain,dc=tld"
+    )
+    assert pw_obj.type == DAVPasswordType.LDAP
+
 
 @pytest.mark.asyncio
 async def test_basic_authentication_basic():


### PR DESCRIPTION
# Checklist

- [X] One Feature(issus) One PR
- [X] Add an entry in `changelog.en.md` if necessary? Don't forget to add your name and github profile link!
- [X] Add / update tests if necessary?
- [X] Add new / update outdated documentation

# Description
This proposal adds a new type of LDAP password, when used with `*ldap` as a username in the configuration, it catches all usernames that are not mapped. Then uses a pattern to substitute the username and build the DN to bind as to the LDAP server.

Fixes #70