### PR TITLE
Implement WebHDFS provider

### DIFF
--- a/.github/workflows/check-pytest.yml
+++ b/.github/workflows/check-pytest.yml
@@ -44,6 +44,8 @@ jobs:
             python3-dev \
             libldap2-dev \
             libsasl2-dev \
+            krb5-multidev \
+            libkrb5-dev \
       - name: Install dependencies
         run: |
           pip install -U -r requirements.d/full.txt

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y krb5-multidev libkrb5-dev
+
       - name: Upgrade pip
         run: |
           # install pip=>20.1 to use "pip cache dir"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An asynchronous WebDAV server implementation, Support multi-provider, multi-acco
 
 - [ASGI](https://asgi.readthedocs.io) standard
 - WebDAV standard: [RFC4918](https://www.ietf.org/rfc/rfc4918.txt)
-- Support multi-provider: FileSystemProvider, MemoryProvider
+- Support multi-provider: FileSystemProvider, MemoryProvider, WebHDFSProvider
 - Support multi-account and permission control
 - Support optional anonymous user
 - Support optional home directory

--- a/asgi_webdav/provider/webhdfs.py
+++ b/asgi_webdav/provider/webhdfs.py
@@ -155,7 +155,16 @@ class WebHDFSProvider(DAVProvider):
             return error.response.status_code, None
 
     async def _do_delete(self, request: DAVRequest) -> int:
-        raise NotImplementedError
+        url_path = self._get_url_path(request.dist_src_path, request.user.username)
+        actual_url = self.uri + f"{url_path}?op=DELETE&recursive=true"
+        try:
+            async with httpx.AsyncClient(auth=kerberos_auth) as client:
+                response = await client.delete(actual_url)
+                response.raise_for_status()
+                return response.status_code
+
+        except httpx.HTTPStatusError as error:
+            return error.response.status_code
 
     async def _do_put(self, request: DAVRequest) -> int:
         raise NotImplementedError

--- a/asgi_webdav/provider/webhdfs.py
+++ b/asgi_webdav/provider/webhdfs.py
@@ -119,7 +119,16 @@ class WebHDFSProvider(DAVProvider):
         raise NotImplementedError
 
     async def _do_mkcol(self, request: DAVRequest) -> int:
-        raise NotImplementedError
+        url_path = self._get_url_path(request.dist_src_path, request.user.username)
+        actual_url = self.uri + f"{url_path}?op=MKDIRS"
+        try:
+            async with httpx.AsyncClient(auth=kerberos_auth) as client:
+                response = await client.put(actual_url)
+                response.raise_for_status()
+                return response.status_code
+
+        except httpx.HTTPStatusError as error:
+            return error.response.status_code
 
     async def _do_get(
         self, request: DAVRequest

--- a/asgi_webdav/provider/webhdfs.py
+++ b/asgi_webdav/provider/webhdfs.py
@@ -1,19 +1,116 @@
 from collections.abc import AsyncGenerator
 from logging import getLogger
+from typing import TypedDict
+from urllib.parse import quote
+
+import httpx
+from httpx_kerberos import HTTPKerberosAuth
 
 from asgi_webdav.constants import (
     DAVPath,
+    DAVPropertyIdentity,
+    DAVTime,
 )
+from asgi_webdav.helpers import guess_type
 from asgi_webdav.property import DAVProperty, DAVPropertyBasicData
 from asgi_webdav.provider.dev_provider import DAVProvider
 from asgi_webdav.request import DAVRequest
 
 logger = getLogger(__name__)
 
+kerberos_auth = HTTPKerberosAuth()
+
+CHUNK_SIZE = 2**16
+
+
+class FileStatus(TypedDict):
+    fileId: int
+    length: int
+    modificationTime: int
+    type: str
+
 
 class WebHDFSProvider(DAVProvider):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.support_content_range = True
+        self.uri = self.uri.rstrip("/")
+
     def __repr__(self):
-        raise NotImplementedError
+        return self.uri
+
+    def _get_url_path(self, path: DAVPath, user_name: str | None) -> DAVPath:
+        """Prepend the requested path with the home directory (if needed)."""
+        if self.home_dir and user_name:
+            return DAVPath(quote(f"/user/{user_name}")).add_child(path)
+        return path
+
+    async def _get_dav_property_d0(
+        self,
+        request: DAVRequest,
+        client: httpx.AsyncClient,
+        url_path: DAVPath,
+    ) -> tuple[int, DAVProperty]:
+        status_code, file_status = await self._do_filestatus(client, url_path)
+        return status_code, await self._create_dav_property_obj(
+            request, url_path, file_status
+        )
+
+    async def _do_filestatus(
+        self, client: httpx.AsyncClient, url_path: DAVPath
+    ) -> tuple[int, FileStatus]:
+        actual_url = self.uri + str(url_path)
+        response = await client.get(actual_url + "?op=GETFILESTATUS")
+        response.raise_for_status()
+        return response.status_code, response.json()["FileStatus"]
+
+    async def _create_dav_property_obj(
+        self,
+        request: DAVRequest,
+        url_path: DAVPath,
+        file_status: FileStatus,
+    ) -> DAVProperty:
+        is_collection = file_status.get("type") == "DIRECTORY"
+
+        if is_collection:
+            basic_data = DAVPropertyBasicData(
+                is_collection=is_collection,
+                display_name=url_path.name,
+                creation_date=DAVTime(float(file_status.get("modificationTime", 0.0))),
+                last_modified=DAVTime(float(file_status.get("modificationTime", 0.0))),
+            )
+
+        else:
+            content_type, content_encoding = guess_type(self.config, url_path.name)
+            charset = None
+
+            basic_data = DAVPropertyBasicData(
+                is_collection=is_collection,
+                display_name=url_path.name,
+                creation_date=DAVTime(float(file_status.get("modificationTime", 0.0))),
+                last_modified=DAVTime(float(file_status.get("modificationTime", 0.0))),
+                content_type=content_type,
+                content_charset=charset,
+                content_length=file_status.get("length"),
+                content_encoding=content_encoding,
+            )
+
+        dav_property = DAVProperty(
+            href_path=url_path, is_collection=is_collection, basic_data=basic_data
+        )
+
+        if request.propfind_only_fetch_basic:
+            return dav_property
+
+        # Extra properties, like: owner, group, permissions
+        extra_data = _get_extra_property(file_status)
+        dav_property.extra_data = extra_data
+
+        # Define not found properties
+        s = set(request.propfind_extra_keys) - set(extra_data.keys())
+        dav_property.extra_not_found = list(s)
+
+        return dav_property
 
     async def _do_propfind(self, request: DAVRequest) -> dict[DAVPath, DAVProperty]:
         raise NotImplementedError
@@ -37,7 +134,16 @@ class WebHDFSProvider(DAVProvider):
     async def _do_head(
         self, request: DAVRequest
     ) -> tuple[int, DAVPropertyBasicData | None]:
-        raise NotImplementedError
+        url_path = self._get_url_path(request.dist_src_path, request.user.username)
+        try:
+            async with httpx.AsyncClient(auth=kerberos_auth) as client:
+                status_response, dav_property = await self._get_dav_property_d0(
+                    request, client, url_path
+                )
+                return status_response, dav_property.basic_data
+
+        except httpx.HTTPStatusError as error:
+            return error.response.status_code, None
 
     async def _do_delete(self, request: DAVRequest) -> int:
         raise NotImplementedError
@@ -53,3 +159,6 @@ class WebHDFSProvider(DAVProvider):
 
     async def _do_move(self, request: DAVRequest) -> int:
         raise NotImplementedError
+
+def _get_extra_property(file_status: FileStatus) -> dict[DAVPropertyIdentity, str]:
+    return {}

--- a/asgi_webdav/provider/webhdfs.py
+++ b/asgi_webdav/provider/webhdfs.py
@@ -175,7 +175,24 @@ class WebHDFSProvider(DAVProvider):
             return dav_properties
 
     async def _do_proppatch(self, request: DAVRequest) -> int:
-        raise NotImplementedError
+        # WebDAV does not natively support the access time property, but HDFS does.
+        # Since WebDAV clients cannot provide an access time, we set HDFS access time to match the modification time.
+
+        # WebDAV does not include a 'group' property as part of its standard properties.
+        # WebDAV does not expose the ability to modify 'owner'
+
+        # HDFS does not support creation time, while WebDAV does.
+        # WebDAV allows setting the creation time as a separate property,
+        # but this information is unavailable or unsupported in HDFS.
+
+        # Permissions are managed through the 'acl' property, which is part of the WebDAV ACL extension.
+        # The 'acl' property is not supported in this implementation.
+
+        parent_exists, file_exists, is_collection = await self._precheck_source(request)
+        if not file_exists:
+            return 404
+
+        return 207
 
     async def _do_mkcol(self, request: DAVRequest) -> int:
         parent_exists, dir_exists, _ = await self._precheck_source(request)

--- a/asgi_webdav/provider/webhdfs.py
+++ b/asgi_webdav/provider/webhdfs.py
@@ -1,0 +1,55 @@
+from collections.abc import AsyncGenerator
+from logging import getLogger
+
+from asgi_webdav.constants import (
+    DAVPath,
+)
+from asgi_webdav.property import DAVProperty, DAVPropertyBasicData
+from asgi_webdav.provider.dev_provider import DAVProvider
+from asgi_webdav.request import DAVRequest
+
+logger = getLogger(__name__)
+
+
+class WebHDFSProvider(DAVProvider):
+    def __repr__(self):
+        raise NotImplementedError
+
+    async def _do_propfind(self, request: DAVRequest) -> dict[DAVPath, DAVProperty]:
+        raise NotImplementedError
+
+    async def _do_proppatch(self, request: DAVRequest) -> int:
+        raise NotImplementedError
+
+    async def _do_mkcol(self, request: DAVRequest) -> int:
+        raise NotImplementedError
+
+    async def _do_get(
+        self, request: DAVRequest
+    ) -> tuple[int, DAVPropertyBasicData | None, AsyncGenerator | None]:
+        # 404, None, None
+        # 200, DAVPropertyBasicData, None  # is_dir
+        # 200/206, DAVPropertyBasicData, AsyncGenerator  # is_file
+        #
+        # self._create_get_head_response_headers()
+        raise NotImplementedError
+
+    async def _do_head(
+        self, request: DAVRequest
+    ) -> tuple[int, DAVPropertyBasicData | None]:
+        raise NotImplementedError
+
+    async def _do_delete(self, request: DAVRequest) -> int:
+        raise NotImplementedError
+
+    async def _do_put(self, request: DAVRequest) -> int:
+        raise NotImplementedError
+
+    async def _do_get_etag(self, request: DAVRequest) -> str:
+        raise NotImplementedError
+
+    async def _do_copy(self, request: DAVRequest) -> int:
+        raise NotImplementedError
+
+    async def _do_move(self, request: DAVRequest) -> int:
+        raise NotImplementedError

--- a/asgi_webdav/web_dav.py
+++ b/asgi_webdav/web_dav.py
@@ -11,6 +11,7 @@ from asgi_webdav.property import DAVProperty
 from asgi_webdav.provider.dev_provider import DAVProvider
 from asgi_webdav.provider.file_system import FileSystemProvider
 from asgi_webdav.provider.memory import MemoryProvider
+from asgi_webdav.provider.webhdfs import WebHDFSProvider
 from asgi_webdav.request import DAVRequest
 from asgi_webdav.response import (
     DAVHideFileInDir,
@@ -97,6 +98,9 @@ class WebDAV:
         for pm in config.provider_mapping:
             if pm.uri.startswith("file://"):
                 provider_factory = FileSystemProvider
+
+            elif pm.uri.startswith("http://") or pm.uri.startswith("https://"):
+                provider_factory = WebHDFSProvider
 
             elif pm.uri.startswith("memory://"):
                 provider_factory = MemoryProvider

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.3 - 20250528
+
+- Implement a WebHDFS provider, contributed by [PIC](https://www.pic.es)
+
 ## 1.4.2 - 20250424
 
 - Fix, ensure expected HTTP response header is included in responses, thanks [SilviaSWR](https://github.com/SilviaSWR)

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -16,7 +16,7 @@ An asynchronous WebDAV server implementation, Support multi-provider, multi-acco
 
 - [ASGI](https://asgi.readthedocs.io) standard
 - WebDAV standard: [RFC4918](https://www.ietf.org/rfc/rfc4918.txt)
-- Support multi-provider: FileSystemProvider, MemoryProvider
+- Support multi-provider: FileSystemProvider, MemoryProvider, WebHDFSProvider
 - Support multi-account and permission control
 - Support optional home directory
 - Support store password in raw/hashlib/LDAP(experimental) mode

--- a/docs/provider/webhdfs.en.md
+++ b/docs/provider/webhdfs.en.md
@@ -1,0 +1,71 @@
+# WebHDFS Provider
+
+## Overview
+
+This provider integrates **WebHDFS** as a backend for the ASGI WebDAV server. It enables read/write access to an HDFS cluster over HTTP(S), using the [WebHDFS REST API](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/WebHDFS.html).
+
+This implementation is **async**, based on `httpx`, and supports optional **Kerberos authentication** via `httpx-kerberos`. It supports user **impersonation** through the `doAs` query parameter when Kerberos is enabled.
+
+---
+
+## Features
+
+- Full support for WebHDFS API over HTTP
+- Async implementation using `httpx`
+- Optional Kerberos authentication via `httpx-kerberos`
+- User impersonation (`doAs`)
+- Optional integration with LDAP
+
+---
+
+## Provider Registration
+
+To use the WebHDFS provider, configure the `provider_mapping` in your main config:
+
+```json
+{
+  "provider_mapping": [
+    {
+      "prefix": "/",
+      "uri": "http://<namenode>:9870/webhdfs/v1"
+    }
+  ]
+}
+```
+* `prefix`: Mount path in the WebDAV hierarchy.
+* `uri`: Full base path to your WebHDFS root (should end with /webhdfs/v1).
+
+##  Authentication Modes
+1. Unauthenticated WebHDFS will accept the user.name query parameter as-is. No verification is done.
+2. Kerberos (recommended)
+If Kerberos is configured on the server and httpx-kerberos is installed:
+* The WebDAV server authenticates as a Kerberos principal.
+* Impersonation is performed using the doAs query parameter in each request to WebHDFS.
+* Requires that the Kerberos principal has impersonation rights in HDFS.
+
+## Dependencies
+Required Python packages:
+```bash
+pip install httpx httpx-kerberos
+```
+
+## Key Components
+* WebHDFSProvider: Implements abstract provider interface.
+* Redirect Handling: Handles 307 redirects issued by the NameNode.
+* Impersonation Logic: Injects doAs param when Kerberos is used.
+* Streaming Support: Uses `httpx`'s async streaming for large files.
+
+## LDAP Integration (Optional)
+Although not required, integrating with an LDAP server allows:
+* Verifying WebDAV user identities before passing to doAs
+* Mapping WebDAV usernames to Kerberos identities
+* Restricting HDFS access based on LDAP groups
+
+## Current Limitations / TODO
+| Feature          | Status        | Notes                                   |
+| ---------------- | ------------- | --------------------------------------- |
+| `PROPPATCH`      | Not supported | Add stub or raise `NotImplementedError` |
+| Directory Quotas | Not handled   | Optional                                |
+| `XAttr` / ACLs   | Not implemented | Not part of base WebDAV spec            |
+
+Feel free to contribute PRs to improve these areas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,10 @@ version = { attr = "asgi_webdav.__version__" }
 dependencies = { file = "requirements.d/basic.txt" }
 
 [tool.setuptools.dynamic.optional-dependencies]
-full = { file = ["requirements.d/standalone.txt", "requirements.d/ldap.txt"] }
+full = { file = ["requirements.d/standalone.txt", "requirements.d/ldap.txt", "requirements.d/webhdfs.txt"] }
 ldap = { file = "requirements.d/ldap.txt" }
 standalone = { file = "requirements.d/standalone.txt" }
+webhdfs = { file = "requirements.d/webhdfs.txt" }
 
 [tool.pytest.ini_options]
 pythonpath = "."

--- a/requirements.d/full.txt
+++ b/requirements.d/full.txt
@@ -1,3 +1,4 @@
 -r basic.txt
 -r ldap.txt
 -r standalone.txt
+-r webhdfs.txt

--- a/requirements.d/webhdfs.txt
+++ b/requirements.d/webhdfs.txt
@@ -1,0 +1,2 @@
+httpx
+httpx-kerberos

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 from asgi_webdav.config import get_config
@@ -47,29 +45,16 @@ def detect_charset_init():
 
 
 @pytest.mark.asyncio
-async def test_detect_charset():
-    detect_charset_init()
+async def test_detect_charset(tmp_path):
+    for encoding, content in detect_charset_content.items():
+        file_path = tmp_path / f"charset-{encoding}.txt"
+        file_path.write_text(content, encoding=encoding)
 
-    charset = await detect_charset(
-        detect_charset_filename_template.format("utf-8"), None
-    )
-    assert charset is None
-    charset = await detect_charset(
-        Path(detect_charset_filename_template.format("utf-8")), None
-    )
-    assert charset is None
-    charset = await detect_charset(
-        Path(detect_charset_filename_template.format("utf-8")), "bad/xxx"
-    )
+    charset = await detect_charset(tmp_path / "charset-utf-8.txt", None)
     assert charset is None
 
-    # TODO
-    # for encoding in detect_charset_content.keys():
-    #     print("current encoding: {}".format(encoding))
-    #     charset = await detect_charset(
-    #         Path(detect_charset_filename_template.format(encoding)), text_charset
-    #     )
-    #     assert charset == encoding
+    charset = await detect_charset(tmp_path / "charset-utf-8.txt", "bad/xxx")
+    assert charset is None
 
 
 def test_is_browser_user_agent():

--- a/tests/test_provider_webhdfs.py
+++ b/tests/test_provider_webhdfs.py
@@ -1,0 +1,37 @@
+from asgi_webdav.config import Config
+from asgi_webdav.constants import DAVPath
+from asgi_webdav.provider.webhdfs import WebHDFSProvider
+
+
+def test_get_url():
+    root = WebHDFSProvider(
+        config=Config(),
+        prefix=DAVPath(""),
+        uri="http://my_domain.com:9870/webhdfs/v1",
+        home_dir=True,
+    )
+    url = root._get_url_path(path=DAVPath("/new_folder/file.txt"), user_name=None)
+    user_url = root._get_url_path(path=DAVPath("/new_folder/file.txt"), user_name="me")
+    url_2 = root._get_url_path(path=DAVPath("/new_folder/file#1.txt"), user_name=None)
+    user_url_2 = root._get_url_path(
+        path=DAVPath("/new_folder/file#1.txt"), user_name="me"
+    )
+    assert url == DAVPath("/new_folder/file.txt")
+    assert user_url == DAVPath("/user/me/new_folder/file.txt")
+    assert url_2 == DAVPath("/new_folder/file%231.txt")
+    assert user_url_2 == DAVPath("/user/me/new_folder/file%231.txt")
+    root_2 = WebHDFSProvider(
+        config=Config(), prefix=DAVPath(""), uri="http://my_domain.com:9870/webhdfs/v1"
+    )
+    url_3 = root_2._get_url_path(path=DAVPath("/new_folder/file.txt"), user_name=None)
+    user_url_3 = root_2._get_url_path(
+        path=DAVPath("/new_folder/file.txt"), user_name="me"
+    )
+    url_4 = root_2._get_url_path(path=DAVPath("/new_folder/file#1.txt"), user_name=None)
+    user_url_4 = root_2._get_url_path(
+        path=DAVPath("/new_folder/file#1.txt"), user_name="me"
+    )
+    assert url_3 == DAVPath("/new_folder/file.txt")
+    assert user_url_3 == DAVPath("/new_folder/file.txt")
+    assert url_4 == DAVPath("/new_folder/file%231.txt")
+    assert user_url_4 == DAVPath("/new_folder/file%231.txt")

--- a/tests/test_provider_webhdfs.py
+++ b/tests/test_provider_webhdfs.py
@@ -9,6 +9,8 @@ def test_get_url():
         prefix=DAVPath(""),
         uri="http://my_domain.com:9870/webhdfs/v1",
         home_dir=True,
+        read_only=False,
+        ignore_property_extra=False,
     )
     url = root._get_url_path(path=DAVPath("/new_folder/file.txt"), user_name=None)
     user_url = root._get_url_path(path=DAVPath("/new_folder/file.txt"), user_name="me")
@@ -21,7 +23,12 @@ def test_get_url():
     assert url_2 == DAVPath("/new_folder/file%231.txt")
     assert user_url_2 == DAVPath("/user/me/new_folder/file%231.txt")
     root_2 = WebHDFSProvider(
-        config=Config(), prefix=DAVPath(""), uri="http://my_domain.com:9870/webhdfs/v1"
+        config=Config(),
+        prefix=DAVPath(""),
+        uri="http://my_domain.com:9870/webhdfs/v1",
+        home_dir=True,
+        read_only=False,
+        ignore_property_extra=False,
     )
     url_3 = root_2._get_url_path(path=DAVPath("/new_folder/file.txt"), user_name=None)
     user_url_3 = root_2._get_url_path(
@@ -32,6 +39,6 @@ def test_get_url():
         path=DAVPath("/new_folder/file#1.txt"), user_name="me"
     )
     assert url_3 == DAVPath("/new_folder/file.txt")
-    assert user_url_3 == DAVPath("/new_folder/file.txt")
+    assert user_url_3 == DAVPath("/user/me/new_folder/file.txt")
     assert url_4 == DAVPath("/new_folder/file%231.txt")
-    assert user_url_4 == DAVPath("/new_folder/file%231.txt")
+    assert user_url_4 == DAVPath("/user/me/new_folder/file%231.txt")

--- a/tests/test_provider_webhdfs.py
+++ b/tests/test_provider_webhdfs.py
@@ -1,9 +1,11 @@
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from asgi_webdav.config import Config
-from asgi_webdav.constants import DAVPath
+from asgi_webdav.constants import DAVPath, DAVTime
+from asgi_webdav.property import DAVProperty, DAVPropertyBasicData
 from asgi_webdav.provider.webhdfs import WebHDFSProvider
 from asgi_webdav.request import DAVRequest
 
@@ -37,6 +39,7 @@ def fake_request():
     request.dist_src_path = DAVPath("/testfile.txt")
     request.propfind_only_fetch_basic = True
     request.propfind_extra_keys = []
+    request.overwrite = True
     return request
 
 
@@ -157,3 +160,208 @@ def test_get_url():
     assert user_url_3 == DAVPath("/user/me/new_folder/file.txt")
     assert url_4 == DAVPath("/new_folder/file%231.txt")
     assert user_url_4 == DAVPath("/user/me/new_folder/file%231.txt")
+
+
+@pytest.mark.asyncio
+async def test_do_filestatus_failure(mock_provider, fake_request):
+    mock_response = AsyncMock()
+    mock_response.status_code = 404
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        message="Error", request=MagicMock(), response=MagicMock(status_code=404)
+    )
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+
+    mock_provider.client.get.return_value = mock_response
+
+    url_path = DAVPath("/notfound.txt")
+
+    response = await mock_provider._do_filestatus(fake_request, url_path)
+    assert response == (404, {})
+
+
+@pytest.mark.asyncio
+async def test_do_get_collection(mock_provider, fake_request):
+    fake_status = {
+        "type": "DIRECTORY",
+        "length": 0,
+        "modificationTime": 1234567890,
+    }
+
+    mock_provider._get_dav_property_d0 = AsyncMock(
+        return_value=(
+            200,
+            await mock_provider._create_dav_property_obj(
+                fake_request, DAVPath("/folder"), fake_status
+            ),
+        )
+    )
+
+    status, basic_data, generator = await mock_provider._do_get(fake_request)
+    assert status == 200
+    assert basic_data.is_collection is True
+    assert generator is None
+
+
+@pytest.mark.asyncio
+async def test_dav_response_data_generator(mock_provider, fake_request):
+    async def fake_aiter_bytes():
+        yield b"chunk1"
+        yield b"chunk2"
+
+    fake_response = MagicMock()
+    fake_response.aiter_bytes = fake_aiter_bytes
+    fake_response.raise_for_status = MagicMock()
+
+    mock_stream_ctx = MagicMock()
+    mock_stream_ctx.__aenter__.return_value = fake_response
+    mock_stream_ctx.__aexit__.return_value = None
+
+    mock_provider.client.stream = MagicMock(return_value=mock_stream_ctx)
+
+    gen = mock_provider._dav_response_data_generator(
+        fake_request,
+        DAVPath("/testfile.txt"),
+        content_range_start=None,
+        content_range_end=None,
+    )
+
+    result = []
+    async for chunk, more in gen:
+        result.append((chunk, more))
+
+    assert result == [(b"chunk1", True), (b"chunk2", False)]
+
+
+@pytest.mark.asyncio
+async def test_do_put(mock_provider, fake_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_provider.client.get.return_value = mock_response
+
+    response = await mock_provider._do_put(fake_request)
+
+    assert response == 204
+
+
+@pytest.mark.asyncio
+async def test_do_copy(mock_provider, fake_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_provider.client.get.return_value = mock_response
+
+    with pytest.raises(NotImplementedError):
+        await mock_provider._do_copy(fake_request)
+
+
+@pytest.mark.asyncio
+async def test_do_mkcol(mock_provider, fake_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_provider.client.get.return_value = mock_response
+
+    response = await mock_provider._do_mkcol(fake_request)
+
+    assert response == 405
+
+
+@pytest.mark.asyncio
+async def test_do_propfind(mock_provider, fake_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_provider.client.get.return_value = mock_response
+
+    response = await mock_provider._do_propfind(fake_request)
+
+    expected = {
+        DAVPath("/testfile.txt"): DAVProperty(
+            href_path=DAVPath("/user/testuser/testfile.txt"),
+            is_collection=False,
+            basic_data=DAVPropertyBasicData(
+                is_collection=False,
+                display_name="testfile.txt",
+                creation_date=DAVTime(0),
+                last_modified=DAVTime(0),
+                content_type="text/plain",
+                content_charset=None,
+                content_length=0,
+                content_encoding=None,
+            ),
+            extra_data={},
+            extra_not_found=[],
+        )
+    }
+
+    assert set(response.keys()) == set(expected.keys())
+
+    for key in expected:
+        resp_val = response[key]
+        exp_val = expected[key]
+
+        assert resp_val.href_path == exp_val.href_path
+        assert resp_val.is_collection == exp_val.is_collection
+
+        assert resp_val.basic_data.is_collection == exp_val.basic_data.is_collection
+        assert resp_val.basic_data.display_name == exp_val.basic_data.display_name
+        assert resp_val.basic_data.content_type == exp_val.basic_data.content_type
+        assert resp_val.basic_data.content_charset == exp_val.basic_data.content_charset
+        assert resp_val.basic_data.content_length == exp_val.basic_data.content_length
+        assert (
+            resp_val.basic_data.content_encoding == exp_val.basic_data.content_encoding
+        )
+
+        assert resp_val.extra_data == exp_val.extra_data
+        assert resp_val.extra_not_found == exp_val.extra_not_found
+
+
+@pytest.mark.asyncio
+async def test_do_head(mock_provider, fake_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_provider.client.get.return_value = mock_response
+
+    response = await mock_provider._do_head(fake_request)
+
+    assert response[0] == 200
+
+
+@pytest.mark.asyncio
+async def test_do_precheck_destination(mock_provider, fake_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_provider.client.get.return_value = mock_response
+
+    response = await mock_provider._precheck_destination(fake_request)
+
+    assert response == (True, False, True)
+
+
+@pytest.mark.asyncio
+async def test_do_move(mock_provider, fake_request):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"FileStatus": {}})
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_provider.client.get.return_value = mock_response
+
+    response = await mock_provider._do_move(fake_request)
+
+    assert response == 204

--- a/tests/test_provider_webhdfs.py
+++ b/tests/test_provider_webhdfs.py
@@ -1,6 +1,121 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from asgi_webdav.config import Config
 from asgi_webdav.constants import DAVPath
 from asgi_webdav.provider.webhdfs import WebHDFSProvider
+from asgi_webdav.request import DAVRequest
+
+
+@pytest.fixture
+def mock_provider(mock_config):
+    provider = WebHDFSProvider(
+        uri="http://fake-hdfs:9870/webhdfs/v1",
+        config=mock_config,
+        home_dir="/user",
+        prefix="",
+        read_only=False,
+        ignore_property_extra=False,
+    )
+    provider.client = AsyncMock()
+    return provider
+
+
+@pytest.fixture
+def mock_config():
+    mock = MagicMock()
+    mock.guess_type_extension.enable = False
+    return mock
+
+
+@pytest.fixture
+def fake_request():
+    request = MagicMock(spec=DAVRequest)
+    request.user.username = "testuser"
+    request.src_path = DAVPath("/testfile.txt")
+    request.dist_src_path = DAVPath("/testfile.txt")
+    request.propfind_only_fetch_basic = True
+    request.propfind_extra_keys = []
+    return request
+
+
+@pytest.mark.asyncio
+async def test_get_url_path_with_home(mock_provider):
+    path = DAVPath("/testfile.txt")
+    result = mock_provider._get_url_path(path, "john")
+    assert str(result).startswith("/user/john")
+    assert "testfile.txt" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_do_filestatus_success(mock_provider, fake_request):
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = AsyncMock()
+
+    mock_response.json = MagicMock(
+        return_value={
+            "FileStatus": {
+                "type": "FILE",
+                "length": 123,
+                "modificationTime": 1234567890,
+            }
+        }
+    )
+
+    mock_provider.client.get.return_value = mock_response
+
+    url_path = DAVPath("/testfile.txt")
+    status_code, file_status = await mock_provider._do_filestatus(
+        fake_request, url_path
+    )
+
+    assert status_code == 200
+    assert file_status["type"] == "FILE"
+
+
+@pytest.mark.asyncio
+async def test_do_get_file(mock_provider, fake_request):
+    fake_status = {
+        "type": "FILE",
+        "length": 100,
+        "modificationTime": 1234567890,
+    }
+
+    mock_provider._get_dav_property_d0 = AsyncMock(
+        return_value=(
+            200,
+            await mock_provider._create_dav_property_obj(
+                fake_request, DAVPath("/testfile.txt"), fake_status
+            ),
+        )
+    )
+    mock_provider._dav_response_data_generator = AsyncMock(return_value=AsyncMock())
+
+    status, basic_data, generator = await mock_provider._do_get(fake_request)
+
+    assert status == 200
+    assert basic_data.content_length == 100
+    assert generator is not None
+
+
+@pytest.mark.asyncio
+async def test_do_delete_success(mock_provider, fake_request):
+    mock_provider._precheck_source = AsyncMock(return_value=(True, True, False))
+    mock_provider.client.delete.return_value = AsyncMock(
+        status_code=204, raise_for_status=AsyncMock()
+    )
+
+    result = await mock_provider._do_delete(fake_request)
+    assert result == 204
+
+
+@pytest.mark.asyncio
+async def test_do_delete_not_found(mock_provider, fake_request):
+    mock_provider._precheck_source = AsyncMock(return_value=(True, False, False))
+    result = await mock_provider._do_delete(fake_request)
+    assert result == 404
 
 
 def test_get_url():

--- a/tests/test_webdav_base.py
+++ b/tests/test_webdav_base.py
@@ -18,6 +18,10 @@ CONFIG_DATA = {
             "prefix": "/",
             "uri": "memory:///",
         },
+        {
+            "prefix": "/webhdfs",
+            "uri": "https://localhost",
+        },
     ],
 }
 
@@ -35,3 +39,8 @@ async def test_base():
         "/", client.create_basic_authorization_headers(USERNAME, PASSWORD)
     )
     assert response.status_code == 200
+    response = await client.get(
+        "https://localhost/webhdfs",
+        client.create_basic_authorization_headers(USERNAME, PASSWORD),
+    )
+    assert response.status_code == 403

--- a/tests/test_webdav_method.py
+++ b/tests/test_webdav_method.py
@@ -52,10 +52,26 @@ class Receive:
         }
 
 
-def get_test_config() -> Config:
-    reinit_config_from_dict(CONFIG_OBJECT)
-    config = get_config()
-    return config
+def get_test_config(fs_root: str | None = None) -> Config:
+    config_object = CONFIG_OBJECT.copy()
+
+    if fs_root:
+        config_object = {
+            **CONFIG_OBJECT,
+            "provider_mapping": [
+                {
+                    "prefix": "/fs",
+                    "uri": f"file://{fs_root}",
+                },
+                {
+                    "prefix": "/memory",
+                    "uri": "memory:///",
+                },
+            ],
+        }
+
+    reinit_config_from_dict(config_object)
+    return get_config()
 
 
 def get_test_scope(
@@ -84,12 +100,15 @@ async def get_response_content(response: DAVResponse) -> bytes:
 
 
 @pytest_asyncio.fixture
-async def setup(provider_name):
+async def setup(provider_name, tmp_path):
     ut_id = uuid4().hex
-    config = get_test_config()
+
+    fs_root = tmp_path / "test_zone"
+    fs_root.mkdir()
+
+    config = get_test_config(fs_root=str(fs_root))
     dav_app = DAVApp(config)
 
-    # prepare
     base_path = f"/{provider_name}/ut-{ut_id}"
 
     scope, receive = get_test_scope("MKCOL", b"", f"{base_path}")
@@ -99,7 +118,6 @@ async def setup(provider_name):
     print(f"{ut_id} {provider_name}\n")
     yield dav_app, base_path
 
-    # cleanup
     scope, receive = get_test_scope("DELETE", b"", f"{base_path}")
     _, response = await dav_app.handle(scope, receive, fake_send)
 


### PR DESCRIPTION
# Checklist

- [X] I have read the [contribution guidelines](https://github.com/ASGI-WebDAV/ASGI-WebDAV/blob/main/CONTRIBUTING.md)
- [X] One Feature(issus) One PR
- [X] All commits in the PR will be merged into a single commit.
- [X] Add an entry in `changelog.en.md` if necessary? Don't forget to add your name and github profile link!
- [ ] Add / update tests if necessary, Don't missing.
- [ ] Add new / update outdated documentation

# Description

Fixes #72

This is an implementation of a WebHDFS provider, using httpx and httpx-kerberos to interface with an external WebHDFS service in an async way.
WebHDFS only allows two modes: unauthenticated (the username provided is taken AS IS), or Kerberos.
If properly configured, a Kerberos user has the ability to impersonate users, and this feature is used in this implementation (through the `doAs` query parameter) to run the commands as the user authenticated to asgi-webdav.
An integration with an LDAP server (see #71) is recommended (but not required).

This proposal ignores any PROPPATCH request, for now. Contributions are welcome.

I haven't added any documentation yet, as it is unclear to me in which section (or maybe a new one) should go.

Let me know how we can proceed from here :)

Best,

Pau.