### PR TITLE
Allow unauthenticated requests, mapped to a predefined user entry

### DIFF
--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -553,7 +553,7 @@ class DAVAuth:
             if not self.config.anonymous_id:
                 return None, "miss header: authorization"
             user = self.user_mapping.get(self.config.anonymous_id)
-            if user is None:
+            if user is None or not user.check_paths_permission([request.path]):
                 return None, "miss header: authorization"
             else:
                 # Server has the anonymous option able

--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -550,9 +550,9 @@ class DAVAuth:
     async def pick_out_user(self, request: DAVRequest) -> tuple[DAVUser | None, str]:
         authorization_header = request.headers.get(b"authorization")
         if authorization_header is None:
-            if not self.config.anonymous_id:
+            if not self.config.unauthenticated_username:
                 return None, "miss header: authorization"
-            user = self.user_mapping.get(self.config.anonymous_id)
+            user = self.user_mapping.get(self.config.unauthenticated_username)
             if user is None or not user.check_paths_permission([request.path]):
                 return None, "miss header: authorization"
             else:

--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -550,7 +550,14 @@ class DAVAuth:
     async def pick_out_user(self, request: DAVRequest) -> tuple[DAVUser | None, str]:
         authorization_header = request.headers.get(b"authorization")
         if authorization_header is None:
-            return None, "miss header: authorization"
+            if not self.config.anonymous_id:
+                return None, "miss header: authorization"
+            user = self.user_mapping.get(self.config.anonymous_id)
+            if user is None:
+                return None, "miss header: authorization"
+            else:
+                # Server has the anonymous option able
+                return user, ""
 
         index = authorization_header.find(b" ")
         if index == -1:

--- a/asgi_webdav/config.py
+++ b/asgi_webdav/config.py
@@ -149,7 +149,7 @@ class Config(JSONWizard):
     account_mapping: list[User] = field(default_factory=list)
     http_basic_auth: HTTPBasicAuth = field(default_factory=HTTPBasicAuth)
     http_digest_auth: HTTPDigestAuth = field(default_factory=HTTPDigestAuth)
-    anonymous_id: str | None = None
+    unauthenticated_username: str | None = None
 
     # provider
     provider_mapping: list[Provider] = field(default_factory=list)

--- a/asgi_webdav/config.py
+++ b/asgi_webdav/config.py
@@ -116,6 +116,7 @@ class Config(BaseModel):
     account_mapping: list[User] = list()  # TODO => user_mapping ?
     http_basic_auth: HTTPBasicAuth = HTTPBasicAuth()
     http_digest_auth: HTTPDigestAuth = HTTPDigestAuth()
+    anonymous_id: str | None = None
 
     # provider
     provider_mapping: list[Provider] = list()  # TODO => prefix_mapping ?

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -5,6 +5,7 @@
 - feat: new config, HTTPBasicAuth.cache_timeout
 - feat: new config, Compression.enable
 - feat: both support .toml and .json config file
+- feat: allow unauthenticated requests, thanks [PIC](https://www.pic.es)
 
 ## 1.5.0 - 20250628
 

--- a/docs/howto/howto-allow-unauthenticated-username.en.md
+++ b/docs/howto/howto-allow-unauthenticated-username.en.md
@@ -1,0 +1,23 @@
+# How to Allow Unauthenticated Username
+
+To enable unauthenticated (anonymous) access, update your`json`config file like below:
+
+```json
+{
+  "unauthenticated_username": "nobody",
+  "account_mapping": [
+    {
+      "username": "nobody",
+      "password": "",
+      "permissions": ["+^/public"]
+    }
+  ]
+}
+```
+
+* When `unauthenticated_username` is set, and a user with that name exists in `account_mapping`
+(with an empty password), any request without authentication will be treated as this user.
+* The `permissions` field controls which paths are accessible to unauthenticated users.
+
+Tip: To disable write access, combine with "read_only": true in the corresponding provider mapping.
+

--- a/docs/reference/config-file.en.md
+++ b/docs/reference/config-file.en.md
@@ -25,6 +25,7 @@ When the file exists, the mapping relationship is defined by the file content.
 
 ```json
 {
+  "unauthenticated_username": "nobody",
   "account_mapping": [
     {
       "username": "username",
@@ -40,6 +41,11 @@ When the file exists, the mapping relationship is defined by the file content.
       "username": "guest",
       "password": "password",
       "permissions": []
+    },
+    {
+      "username": "nobody",
+      "password": "",
+      "permissions": ["+^/public"]
     }
   ],
   "http_basic_auth": {
@@ -75,6 +81,9 @@ When the file exists, the mapping relationship is defined by the file content.
 }
 ```
 
+**Note**: When `unauthenticated_username` is set and a user with that name exists in `account_mapping`
+(typically with an empty password), requests with no authentication will be mapped to that user. Permissions of that user will determine allowed access for unauthenticated clients.
+
 #### logging output
 
 ```text
@@ -82,6 +91,7 @@ INFO: [asgi_webdav.server] ASGI WebDAV Server(v1.3.2) starting...
 INFO: [asgi_webdav.auth] Register Account: username, allow:[''], deny:[]
 INFO: [asgi_webdav.auth] Register Account: litmus, allow:['^/$', '^/litmus'], deny:['^/litmus/other']
 INFO: [asgi_webdav.auth] Register Account: guest, allow:[], deny:[]
+INFO: [asgi_webdav.auth] Register Account: nobody, allow:['^/public'], deny:[]
 INFO: [asgi_webdav.web_dav] Mapping Prefix: / --[ReadOnly]--> file:///data/root
 INFO: [asgi_webdav.web_dav] Mapping Prefix: /provider --[ReadOnly]--> memory:///
 INFO: [asgi_webdav.web_dav] Mapping Prefix: /provider/fs --> file:///tmp
@@ -99,6 +109,7 @@ root object
 
 | Key                      | Use For  | Value Type              | Default Value             |
 | ------------------------ | -------- | ----------------------- | ------------------------- |
+| unauthenticated_username | auth     | `str`                   | `None`                    |
 | account_mapping          | auth     | `list[User]`            | `[]`                      |
 | http_basic_auth          | auth     | `HTTPBasicAuth`         | `HTTPBasicAuth()`         |
 | http_digest_auth         | auth     | `HTTPDigestAuth`        | `HTTPDigestAuth()`        |
@@ -114,6 +125,7 @@ Example
 
 ```text
 {
+    "unauthenticated_username": "nobody",
     "account_mapping": [...],
     "http_digest_auth": {...},
     "provider_mapping": [...],
@@ -141,6 +153,18 @@ Example
 | admin       | bool       | `false`       |
 
 - When the value of `admin` is `true`, the user can access the web page `/_/admin/xxx`
+- If `unauthenticated_username` is set and refers to a user with an empty password, that user will be used for 
+unauthenticated (anonymous) requests.
+
+Example:
+```json
+{
+  "username": "nobody",
+  "password": "",
+  "permissions": ["+^/public"]
+}
+```
+
 
 ### `Permissions` Format/Example
 


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.
-->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/ASGI-WebDAV/ASGI-WebDAV/blob/main/CONTRIBUTING.md)
- [X] One Feature(issus) One PR
- [X] All commits in the PR will be merged into a single commit.
- [ ] Add an entry in `changelog.en.md` if necessary? Don't forget to add your name and github profile link!
- [ ] Add / update tests if necessary, Don't missing.
- [ ] Add new / update outdated documentation

# Description

Very minor change in how unauthenticated requests are handled.
If an `anonymous_id` is configured, unauthenticated requests are mapped to that user entry.
If note defined, behaviour is unchanged.

fixes #77

