### PR TITLE
fix(auth): only evaluate anonymous user on configured anonymous path

### DIFF
--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -573,7 +573,10 @@ class DAVAuth:
 
         authorization_header = request.headers.get(b"authorization")
         if authorization_header is None:
-            if self.anonymous_user is None:
+            if (
+                self.anonymous_user is None
+                or not self.anonymous_user.check_paths_permission([request.src_path])
+            ):
                 return None, "miss header: authorization"
             else:
                 # Server has the anonymous option able

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -301,7 +301,7 @@ async def test_basic_authentication_anonymous_user():
     response = await client.get(
         "/no_permission",
     )
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 def test_dav_user_check_paths_permission():


### PR DESCRIPTION
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/ASGI-WebDAV/ASGI-WebDAV/blob/main/CONTRIBUTING.md)
- [x] One Feature(issus) One PR
- [x] All commits in the PR will be merged into a single commit.
- [x] Add an entry in `changelog.en.md` if necessary? Don't forget to add your name and github profile link!
- [x] Add / update tests if necessary, Don't missing.
- [x] Add new / update outdated documentation

# Description

Currently, the system assigns the anonymous user whenever no credentials are detected.  
As a result, the user is never actually prompted for a password, because they are automatically treated as anonymous.  

This behavior has a significant impact when using web browsers as a tool to access WebDAV, since users are never prompted to log in.

The proposed fix is to only assign the anonymous user when the accessed path is the one configured for anonymous access.

**Expected behavior:**  
The anonymous user should only be applied when accessing the configured
anonymous path. For all other paths, valid authentication must be required.

Issue #80 