### PR TITLE
feat(webdav): Add configurable extra footer HTML support

### DIFF
--- a/asgi_webdav/config.py
+++ b/asgi_webdav/config.py
@@ -184,6 +184,7 @@ class Config(JSONPyWizard):
     compression: Compression = field(default_factory=Compression)
     cors: CORS = field(default_factory=CORS)
     enable_dir_browser: bool = True
+    extra_footer_path: str | None = None
 
     # other
     logging: Logging = field(default_factory=Logging)

--- a/asgi_webdav/web_dav.py
+++ b/asgi_webdav/web_dav.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import copy
 from dataclasses import dataclass
 from logging import getLogger
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from asgi_webdav import __version__
@@ -34,7 +35,7 @@ _CONTENT_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Index of {}</title>
+  <title>Index of {path}</title>
   <style>
     table {{ table-layout: auto;width: 100%; }}
     tbody tr:nth-of-type(even) {{ background-color: #f3f3f3; }}
@@ -44,7 +45,7 @@ _CONTENT_TEMPLATE = """<!DOCTYPE html>
 </head>
 <body>
   <header>
-    <h1>Index of <small>{}</small></h1>
+    <h1>Index of <small>{path}</small></h1>
   </header>
   <hr>
   <main>
@@ -55,16 +56,19 @@ _CONTENT_TEMPLATE = """<!DOCTYPE html>
     <th class="align-right">Size</th><th class="align-right">Last modified</th>
     </tr>
   </thead>
-  <tbody>{}</tbody>
+  <tbody>{table_rows}</tbody>
   </table>
   </main>
   <hr>
   <footer>
-    <a href="https://rexzhang.github.io/asgi-webdav">ASGI WebDAV: v{}</a>,
-    <small>
-    current time: {},
-    <a href="https://github.com/rexzhang/asgi-webdav/issues">report issue</a>
-    </small>
+    <p>
+      <a href="https://rexzhang.github.io/asgi-webdav">ASGI WebDAV: v{version}</a>,
+      <small>
+        current time: {current_time},
+        <a href="https://github.com/rexzhang/asgi-webdav/issues">report issue</a>
+      </small>
+    </p>
+    <p>{extra_footer}</p>
   </footer>
 </body>
 </html>"""
@@ -154,6 +158,20 @@ class WebDAV:
             self.timezone = get_timezone()
         except DAVException as e:
             DAVException(f"Please check environment variable: TZ, {e}")
+
+        self._load_extra_footer_html(config)
+
+    def _load_extra_footer_html(self, config: Config):
+        self.extra_footer_html = ""
+        if config.extra_footer_path:
+            footer_path = Path(config.extra_footer_path)
+            if footer_path.is_file():
+                try:
+                    self.extra_footer_html = footer_path.read_text(encoding="utf-8")
+                except OSError as e:
+                    logger.warning(
+                        f"Failed to read extra footer file {footer_path}: {e}"
+                    )
 
     @staticmethod
     def match_provider_class(
@@ -469,10 +487,10 @@ class WebDAV:
                 )
 
         content = _CONTENT_TEMPLATE.format(
-            root_path.raw,
-            root_path.raw,
-            tbody_parent + tbody_dir + tbody_file,
-            __version__,
-            DAVTime().display(self.timezone),
+            path=root_path.raw,
+            table_rows=tbody_parent + tbody_dir + tbody_file,
+            version=__version__,
+            current_time=DAVTime().display(self.timezone),
+            extra_footer=self.extra_footer_html,
         )
         return content.encode("utf-8")

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -2,7 +2,7 @@
 
 The `asgi-webdav` project thrives on the contributions of the open-source community. We would like to extend our sincere gratitude to the organizations and individuals who have dedicated their time and resources to making this project better.
 
-## PIC
+## [PIC](https://www.pic.es)
 
 (1) This contribution has received funding from the Spanish government (grant EQC2021-007479-P, funded by MCIN/AEI/10.13039/501100011033), the EU
 NextGeneration/PRTR (PRTR-C17.I1), and the Generalitat de Catalunya.

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2 - 20260420
+
+- feat: support for configurable extra HTML footer via `extra_footer_path`, contributed by [PIC](https://www.pic.es) [1](docs/acknowledgements.md#PIC)
+
 ## 2.0.1 - 20260220
 
 - fix(webhdfs): convert timestamps from milliseconds using DAVTime (#89)

--- a/docs/reference/config-file.en.md
+++ b/docs/reference/config-file.en.md
@@ -111,6 +111,7 @@ root object
 | enable_dir_browser       | response | `bool`                  | `true`                    |
 | logging                  | other    | `Logging`               | `"Logging()"`             |
 | sentry_dsn               | other    | `str`                   | `None`                    |
+| extra_footer_path        | other    | `str/None`              | `None`                    |
 
 ## for Authentication
 


### PR DESCRIPTION
# Description

This PR adds support for injecting a custom footer into the generated HTML via `extra_footer_path`.

The footer content is loaded from a file and inserted into the HTML template, allowing configurable footer content in directory listings.

No changes are made to static file serving or resource handling.

fixes #91

# Checklist

- [X] I have read the contribution guidelines
- [X] One feature (issue) per PR
- [X] All commits will be squashed into a single commit
- [X] Changelog updated if necessary
- [X] Tests added/updated if necessary
- [X] Documentation updated if necessary