### PR TITLE
feat: OIDC Bearer token auth and documentation

### DIFF
--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -18,7 +18,11 @@ from asgi_webdav.cache import (
 )
 from asgi_webdav.config import Config
 from asgi_webdav.constants import DAVMethod, DAVUpperEnumAbc, DAVUser
-from asgi_webdav.exceptions import DAVExceptionAuthFailed, DAVExceptionConfig
+from asgi_webdav.exceptions import (
+    DAVExceptionAuthFailed,
+    DAVExceptionConfig,
+    DAVExceptionProviderInitFailed,
+)
 from asgi_webdav.request import DAVRequest
 from asgi_webdav.response import DAVResponse
 
@@ -30,6 +34,14 @@ try:
 except ImportError:
     bonsai = None
     bonsai_exception = None
+
+jwt: Any | None = None
+PyJWKClient: Any | None = None
+try:
+    import jwt
+    from jwt import PyJWKClient
+except ImportError:
+    pass
 
 logger = getLogger(__name__)
 
@@ -66,6 +78,7 @@ class DAVPasswordType(DAVUpperEnumAbc):
     HASHLIB = ":", 4
     DIGEST = ":", 3
     LDAP = "#", 5
+    OIDC = "#", 8
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -306,6 +319,10 @@ class HTTPBasicAuth(HTTPAuthAbc):
                     user.username, password
                 )
 
+            case DAVPasswordType.OIDC:
+                # OIDC Bearer auth only, Basic auth not supported
+                valid, message = False, "OIDC does not support Basic auth"
+
             case _:
                 valid, message = False, pw_obj.message
 
@@ -516,6 +533,73 @@ class HTTPDigestAuth(HTTPAuthAbc):
         )
 
 
+class HTTPOIDCAuth:
+    """
+    OpenID Connect (OIDC) Bearer token authentication.
+
+    Verifies a JWT access token locally against the IdP's JWKS public keys
+    (no network introspection per request). Connection details live in the
+    `*oidc` template user's password field, mirroring the `<ldap>` convention:
+
+        <oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope
+    """
+
+    DEFAULT_SCOPE = "openid"
+
+    def __init__(self, password_data: DAVPassword):
+        if jwt is None or PyJWKClient is None:
+            raise DAVExceptionConfig(
+                "Please install OIDC module: pip install -U ASGIWebDAV[oidc]"
+            )
+
+        # <oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope
+        if password_data[1] != "1":
+            raise DAVExceptionConfig(
+                f"Unsupported OIDC password version: {password_data[1]}"
+            )
+
+        self.issuer = password_data[2]
+        self.jwks_uri = password_data[3]
+        self.audience = password_data[4]
+        self.client_id = password_data[5]
+        self.algorithm = password_data[6]
+        self.scope = password_data[7]
+
+        # Eagerly fetch JWKS — failure is fatal at startup
+        try:
+            self._jwks_client = PyJWKClient(self.jwks_uri)
+            self._jwks_client.get_jwk_set()
+        except Exception as e:
+            raise DAVExceptionProviderInitFailed(
+                f"Failed to fetch JWKS from {self.jwks_uri}: {e}"
+            ) from e
+
+    def verify_token(self, token: str) -> dict[str, Any]:
+        try:
+            signing_key = self._jwks_client.get_signing_key_from_jwt(token).key
+            decoded = jwt.decode(
+                token,
+                key=signing_key,
+                algorithms=[self.algorithm],
+                audience=self.audience,
+                issuer=self.issuer,
+                options={"verify_exp": True},
+            )
+        except Exception as e:
+            raise DAVExceptionAuthFailed(str(e)) from e
+
+        # Manual claim checks
+        token_scopes = set(decoded.get("scope", "").split())
+        if (
+            decoded.get("azp") != self.client_id
+            or decoded.get("typ") != "Bearer"
+            or self.scope not in token_scopes
+        ):
+            raise DAVExceptionAuthFailed("Invalid access_token")
+
+        return decoded
+
+
 MESSAGE_401_TEMPLATE = """<!DOCTYPE html>
 <html>
   <head>
@@ -571,6 +655,19 @@ class DAVAuth:
             cache_timeout=self.config.http_basic_auth.cache_timeout,
         )
         self.http_digest_auth = HTTPDigestAuth(realm=self.realm, secret=uuid4().hex)
+
+        # OIDC auth (optional, uses *oidc template user)
+        self.oidc_auth: HTTPOIDCAuth | None = None
+        oidc_template = self.user_mapping.get("*oidc")
+        if oidc_template is not None:
+            pw_obj = DAVPassword(oidc_template.password)
+            if pw_obj.type == DAVPasswordType.OIDC:
+                self.oidc_auth = HTTPOIDCAuth(pw_obj.data)
+                logger.info("OIDC Bearer auth enabled")
+            else:
+                raise DAVExceptionConfig(
+                    "The password of the *oidc user must use the <oidc> format"
+                )
 
     # async def pick_out_user(self, request: DAVRequest) -> tuple[DAVUser | None, str]:
     async def pick_out_user(self, request: DAVRequest) -> None | str:
@@ -669,6 +766,39 @@ class DAVAuth:
             request.user = user
             return None
 
+        # HTTP Bearer Auth (OIDC)
+        if auth_header_type.lower() == b"bearer":
+            request.authorization_method = "Bearer"
+            if self.oidc_auth is None:
+                return "OpenID not available"
+
+            try:
+                # Check token validity
+                token_data = self.oidc_auth.verify_token(auth_header_data.decode())
+            except DAVExceptionAuthFailed:
+                return "no permission"
+
+            # Get user name to get permissions from the data file. The OIDC claims are not used for permissions.
+            username = token_data.get("preferred_username", None)
+            if username is None:
+                return "no permission"
+            user = self.user_mapping.get(
+                username
+            )  # Permission specified in the data file takes precedence over OIDC claims.
+            if user is None:
+                # The user does not exist in the data file, but may be in the OIDC fallback.
+                fallback = self.user_mapping.get(
+                    "*oidc"
+                )  # Default OIDC permission template user, if configured.
+                if fallback is None:
+                    return "no permission"
+
+                user = copy.copy(fallback)
+                user.username = username
+
+            request.user = user
+            return None
+
         return "Unknown authentication method"
 
     def create_response_401(self, request: DAVRequest, message: str) -> DAVResponse:
@@ -696,6 +826,10 @@ class DAVAuth:
         else:
             challenge_string = self.http_basic_auth.make_auth_challenge_string()
             logger.debug("response Basic auth challenge")
+
+        # Append Bearer challenge per RFC 6750 when OIDC is configured
+        if self.oidc_auth is not None:
+            challenge_string += b", Bearer"
 
         return DAVResponse(
             status=401,

--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -78,7 +78,7 @@ class DAVPasswordType(DAVUpperEnumAbc):
     HASHLIB = ":", 4
     DIGEST = ":", 3
     LDAP = "#", 5
-    OIDC = "#", 8
+    OIDC = "#", 9
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -541,7 +541,7 @@ class HTTPOIDCAuth:
     (no network introspection per request). Connection details live in the
     `*oidc` template user's password field, mirroring the `<ldap>` convention:
 
-        <oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope
+        <oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope#group_prefix
     """
 
     DEFAULT_SCOPE = "openid"
@@ -552,7 +552,7 @@ class HTTPOIDCAuth:
                 "Please install OIDC module: pip install -U ASGIWebDAV[oidc]"
             )
 
-        # <oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope
+        # <oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope#group_prefix
         if password_data[1] != "1":
             raise DAVExceptionConfig(
                 f"Unsupported OIDC password version: {password_data[1]}"
@@ -564,6 +564,7 @@ class HTTPOIDCAuth:
         self.client_id = password_data[5]
         self.algorithm = password_data[6]
         self.scope = password_data[7]
+        self.group_prefix = password_data[8]
 
         # Eagerly fetch JWKS — failure is fatal at startup
         try:
@@ -671,6 +672,20 @@ class DAVAuth:
                 raise DAVExceptionConfig(
                     "The password of the *oidc user must use the <oidc> format"
                 )
+
+    def _extract_groups_permissions(
+        self, token_data: dict[str, Any], group_prefix: str
+    ) -> list[str]:
+        """Extract permission strings from the token's groups claim, filtered by prefix."""
+        groups = token_data.get("groups")
+        if not groups or not isinstance(groups, list):
+            return []
+
+        permissions: list[str] = []
+        for group in groups:
+            if isinstance(group, str) and group.startswith(group_prefix):
+                permissions.append(group[len(group_prefix) :])
+        return permissions
 
     # async def pick_out_user(self, request: DAVRequest) -> tuple[DAVUser | None, str]:
     async def pick_out_user(self, request: DAVRequest) -> None | str:
@@ -781,23 +796,42 @@ class DAVAuth:
             except DAVExceptionAuthFailed:
                 return "no permission"
 
-            # Get user name to get permissions from the data file. The OIDC claims are not used for permissions.
+            # Resolve user identity
             oidc_username: str | None = token_data.get("preferred_username", None)
             if oidc_username is None:
                 return "no permission"
+
+            # Priority 1: user explicitly listed in config → use config permissions
             user = self.user_mapping.get(
                 oidc_username
             )  # Permission specified in the data file takes precedence over OIDC claims.
-            if user is None:
-                # The user does not exist in the data file, but may be in the OIDC fallback.
-                fallback = self.user_mapping.get(
-                    "*oidc"
-                )  # Default OIDC permission template user, if configured.
-                if fallback is None:
-                    return "no permission"
+            if user is not None:
+                request.user = user
+                return None
 
-                user = copy.copy(fallback)
-                user.username = oidc_username
+            # Priority 2: user not in config → try token groups
+            group_permissions = self._extract_groups_permissions(
+                token_data, self.oidc_auth.group_prefix
+            )
+            if group_permissions:
+                user = DAVUser(
+                    username=oidc_username,
+                    password="",
+                    permissions=group_permissions,
+                    admin=False,
+                )
+                request.user = user
+                return None
+
+            # Priority 3: no usable groups → fall back to *oidc template
+            fallback = self.user_mapping.get(
+                "*oidc"
+            )  # Default OIDC permission template user, if configured.
+            if fallback is None:
+                return "no permission"
+
+            user = copy.copy(fallback)
+            user.username = oidc_username
 
             request.user = user
             return None

--- a/asgi_webdav/auth.py
+++ b/asgi_webdav/auth.py
@@ -546,7 +546,7 @@ class HTTPOIDCAuth:
 
     DEFAULT_SCOPE = "openid"
 
-    def __init__(self, password_data: DAVPassword):
+    def __init__(self, password_data: list[str]):
         if jwt is None or PyJWKClient is None:
             raise DAVExceptionConfig(
                 "Please install OIDC module: pip install -U ASGIWebDAV[oidc]"
@@ -576,8 +576,11 @@ class HTTPOIDCAuth:
 
     def verify_token(self, token: str) -> dict[str, Any]:
         try:
+            if jwt is None:
+                # guarantee by __init__, but mypy doesn't know that
+                raise DAVExceptionConfig("JWT library not initialized")
             signing_key = self._jwks_client.get_signing_key_from_jwt(token).key
-            decoded = jwt.decode(
+            decoded: dict[str, Any] = jwt.decode(
                 token,
                 key=signing_key,
                 algorithms=[self.algorithm],
@@ -779,11 +782,11 @@ class DAVAuth:
                 return "no permission"
 
             # Get user name to get permissions from the data file. The OIDC claims are not used for permissions.
-            username = token_data.get("preferred_username", None)
-            if username is None:
+            oidc_username: str | None = token_data.get("preferred_username", None)
+            if oidc_username is None:
                 return "no permission"
             user = self.user_mapping.get(
-                username
+                oidc_username
             )  # Permission specified in the data file takes precedence over OIDC claims.
             if user is None:
                 # The user does not exist in the data file, but may be in the OIDC fallback.
@@ -794,7 +797,7 @@ class DAVAuth:
                     return "no permission"
 
                 user = copy.copy(fallback)
-                user.username = username
+                user.username = oidc_username
 
             request.user = user
             return None

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 - 20260716
+
+- feat: OIDC Bearer token authentication — verify JWT access tokens locally against an IdP's JWKS public keys. Configure via the `*oidc` sentinel user in `account_mapping` with `<oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope` password format. Authenticated Bearer users inherit `*oidc` template permissions if not explicitly listed in `account_mapping`, thanks [PIC](https://www.pic.es) [1](acknowledgements.md#pic)
+
 ## 2.0.1 - 20260220
 
 - fix(webhdfs): convert timestamps from milliseconds using DAVTime (#89)

--- a/docs/changelog.en.md
+++ b/docs/changelog.en.md
@@ -2,7 +2,8 @@
 
 ## 2.1.0 - 20260716
 
-- feat: OIDC Bearer token authentication — verify JWT access tokens locally against an IdP's JWKS public keys. Configure via the `*oidc` sentinel user in `account_mapping` with `<oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope` password format. Authenticated Bearer users inherit `*oidc` template permissions if not explicitly listed in `account_mapping`, thanks [PIC](https://www.pic.es) [1](acknowledgements.md#pic)
+- feat: OIDC Bearer token authentication — verify JWT access tokens locally against an IdP's JWKS public keys. Configure via the `*oidc` sentinel user in `account_mapping` with `<oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope#group_prefix` password format. Authenticated Bearer users inherit `*oidc` template permissions if not explicitly listed in `account_mapping`, thanks [PIC](https://www.pic.es) [1](acknowledgements.md#pic)
+- feat: OIDC Bearer users not listed in `account_mapping` can receive permissions from the token's `groups` claim. Groups are filtered by a configurable prefix (e.g. `asgi-webdav_`); matching entries are used as permission patterns after prefix stripping. The `*oidc` template serves as fallback when no matching groups are present. The IdP is trusted to provide valid permission patterns — no validation is performed on group values, thanks [PIC](https://www.pic.es) [1](acknowledgements.md#pic)
 
 ## 2.0.1 - 20260220
 

--- a/docs/guide/authentication.en.md
+++ b/docs/guide/authentication.en.md
@@ -76,6 +76,62 @@ When a client sends `Authorization: Bearer <access_token>`:
 
 See [Protect your password](protect-your-password-in-the-config.en.md#oidc-openid-connect-bearer-auth) for configuration details.
 
+#### OpenID Connect Access Token Requirements
+
+To authenticate using OpenID Connect, the Identity Provider (IdP) **must issue a JWT access token** containing the following claims.
+
+The server validates these claims to ensure the token was issued by the expected provider, intended for this application, and grants the required permissions.
+
+| Claim | Required | Description |
+|--------|----------|-------------|
+| `iss` | Yes | The issuer of the token. Must match the configured OIDC issuer URL. |
+| `aud` | Yes | The intended audience of the token. Must match the configured audience for this application. |
+| `azp` | Yes | The authorized party (OAuth client ID). Must match the configured client ID. |
+| `typ` | Yes* | Must be `Bearer`. Some providers omit this claim because all OAuth access tokens are bearer tokens by definition. |
+| `scope` | Yes | Space-separated list of granted scopes. Must include the configured required scope. |
+| `preferred_username` | Yes | Username associated with the authenticated user. Used as the application identity. |
+| `groups` | Optional | List of group memberships. Can be mapped to application permissions using `group_prefix`. |
+| `exp` | Yes | Expiration timestamp (Unix epoch). Expired tokens are rejected. |
+
+##### Example
+
+```json
+{
+  "iss": "https://idp.example.com/realms/main",
+  "aud": "webdav",
+  "azp": "webdav-client",
+  "typ": "Bearer",
+  "scope": "openid webdav",
+  "preferred_username": "alice",
+  "groups": [
+    "webdav:read",
+    "webdav:write"
+  ],
+  "exp": 1750000000
+}
+```
+
+##### Claim validation
+
+During authentication the server performs the following checks:
+
+| Claim | Validation |
+|--------|------------|
+| `iss` | Must equal the configured issuer. |
+| `aud` | Must contain the configured audience. |
+| `azp` | Must equal the configured client ID. |
+| `typ` | Must be `Bearer` (if present). |
+| `scope` | Must contain the required scope. |
+| `preferred_username` | Used as the authenticated username. |
+| `groups` | Optionally mapped to application permissions. |
+| `exp` | Must be in the future. |
+
+##### Compatibility
+
+Most OpenID Connect providers (including Keycloak, Authentik, Authelia, Dex, Zitadel and others) can be configured to produce tokens compatible with these requirements.
+
+The exact set of claims included in the access token depends on the provider configuration and the scopes requested by the client. In particular, claims such as `preferred_username` and `groups` typically require the corresponding OIDC scopes (for example `profile` and `groups`) to be granted.
+
 ## Anonymous Account
 
 More detail, please see howto.

--- a/docs/guide/authentication.en.md
+++ b/docs/guide/authentication.en.md
@@ -23,22 +23,58 @@ flowchart TB
 
 ## Match/Check Account
 
+The server supports three authentication methods, checked in this order:
+
+1. **HTTP Basic Auth** — `Authorization: Basic <base64(user:password)>`
+2. **HTTP Digest Auth** — `Authorization: Digest <digest-data>`
+3. **HTTP Bearer Auth (OIDC)** — `Authorization: Bearer <access_token>`
+4. **Anonymous** — no `Authorization` header, falls back to the anonymous user (if enabled)
+
 ```mermaid
 flowchart TB
     START@{ shape: sm-circ, label: "Small start" }
     END@{ shape: framed-circle, label: "Stop" }
     HTTP_HEADER_CHECK{{Get HTTP header: authorization}}
-    HTTP_AUTH[[HTTP Basic/Digest Auth Logic]]
+    BASIC_AUTH{{Is Basic?}}
+    DIGEST_AUTH{{Is Digest?}}
+    BEARER_AUTH{{Is Bearer?}}
+    BASIC_LOGIC[[Basic Auth: parse credentials, verify password]]
+    DIGEST_LOGIC[[Digest Auth: verify digest response]]
+    BEARER_LOGIC[[Bearer Auth: verify JWT signature + claims, extract preferred_username]]
     ALLOW_MISSING_AUTH_HEADER{{config.anonymous.enable and config.anonymous.allow_missing_auth_header?}}
 
     START--> HTTP_HEADER_CHECK
-    HTTP_HEADER_CHECK -->|Got| HTTP_AUTH
     HTTP_HEADER_CHECK -->|None| ALLOW_MISSING_AUTH_HEADER
-    HTTP_AUTH -->|match| USER_IS_X[User = X or Anonymous] --> END
-    HTTP_AUTH -->|failed| 401([HTTP 401/Unauthorized])
+    HTTP_HEADER_CHECK -->|Got| BASIC_AUTH
+    BASIC_AUTH -->|Yes| BASIC_LOGIC
+    BASIC_AUTH -->|No| DIGEST_AUTH
+    DIGEST_AUTH -->|Yes| DIGEST_LOGIC
+    DIGEST_AUTH -->|No| BEARER_AUTH
+    BEARER_AUTH -->|Yes| BEARER_LOGIC
+    BEARER_AUTH -->|No| 401_UNKNOWN([HTTP 401 - Unknown auth method])
+
+    BASIC_LOGIC -->|match| USER_IS_X[User authenticated] --> END
+    BASIC_LOGIC -->|failed| 401([HTTP 401/Unauthorized])
+    DIGEST_LOGIC -->|match| USER_IS_X
+    DIGEST_LOGIC -->|failed| 401
+    BEARER_LOGIC -->|match| USER_IS_X
+    BEARER_LOGIC -->|failed| 401
+
     ALLOW_MISSING_AUTH_HEADER -->|False| 401
     ALLOW_MISSING_AUTH_HEADER -->|True| USER_IS_ANONYMOUS[User = Anonymous] --> END
 ```
+
+### Bearer Auth (OIDC)
+
+When a client sends `Authorization: Bearer <access_token>`:
+
+1. The JWT is verified locally against the IdP's JWKS public keys (fetched at startup).
+2. Required claims are checked: `iss`, `aud`, `azp`, `typ` ("Bearer"), `scope`, `exp`.
+3. The `preferred_username` claim is extracted and looked up in `account_mapping`.
+4. If found, that user's permissions are used. If not found, the `*oidc` template permissions are inherited.
+5. If the token is invalid or the subject is not configured, HTTP 401 is returned.
+
+See [Protect your password](protect-your-password-in-the-config.en.md#oidc-openid-connect-bearer-auth) for configuration details.
 
 ## Anonymous Account
 

--- a/docs/guide/protect-your-password-in-the-config.en.md
+++ b/docs/guide/protect-your-password-in-the-config.en.md
@@ -190,7 +190,7 @@ Use `"*oidc"` as `username`. This is a sentinel entry that configures the OIDC p
 ### password format
 
 ```text
-"<oidc>#1#{issuer}#{jwks_uri}#{audience}#{client_id}#{algorithm}#{scope}"
+"<oidc>#1#{issuer}#{jwks_uri}#{audience}#{client_id}#{algorithm}#{scope}#{group_prefix}"
 ```
 
 ### {issuer}
@@ -247,12 +247,14 @@ Example:
 
 ### Example configuration
 
+#### With default permissions for all Bearer users
+
 ```json
 {
   "account_mapping": [
     {
       "username": "*oidc",
-      "password": "<oidc>#1#https://idp.example.com/realms/PIC#https://idp.example.com/realms/institution/protocol/openid-connect/certs#account#cosmohub-test#RS256#openid",
+      "password": "<oidc>#1#https://idp.example.com/realms/PIC#https://idp.example.com/realms/institution/protocol/openid-connect/certs#account#cosmohub-test#RS256#openid#asgi-webdav_",
       "permissions": ["+^/$"]
     },
     {
@@ -268,7 +270,64 @@ In this example:
 
 - `*oidc` configures the OIDC provider and grants default permissions `+^/$` (root only) to any authenticated Bearer user.
 - `alice` is an explicitly configured user. When `alice` authenticates via Bearer, she gets `+^/data/public` permissions (more permissive than the default).
-- Any other Keycloak user (e.g. `bob`) who presents a valid token inherits the `*oidc` default permissions (`+^/$`).
+- Any other Keycloak user (e.g. `bob`) who presents a valid token inherits the `*oidc` default permissions (`+^/$`), unless the token contains groups matching the `asgi-webdav_` prefix, in which case those groups are used as permissions instead.
+
+#### Without default permissions (per-user config only)
+
+```json
+{
+  "account_mapping": [
+    {
+      "username": "*oidc",
+      "password": "<oidc>#1#https://idp.example.com/realms/PIC#https://idp.example.com/realms/institution/protocol/openid-connect/certs#account#cosmohub-test#RS256#openid#asgi-webdav_",
+      "permissions": []
+    },
+    {
+      "username": "alice",
+      "password": "secret",
+      "permissions": ["+^/$", "+^/data/**"]
+    },
+    {
+      "username": "bob",
+      "password": "secret",
+      "permissions": ["+^/$", "+^/shared/**"]
+    }
+  ]
+}
+```
+
+In this example:
+
+- `*oidc` only configures the OIDC provider; the empty `permissions` list means unknown Bearer users without matching groups are denied access.
+- `alice` and `bob` are listed explicitly with their own permissions.
+- Only users present in `account_mapping` are granted access, with permissions defined in the config file. Users not in `account_mapping` can still receive permissions via token groups matching the `asgi-webdav_` prefix.
+
+#### All permissions from OAuth (IdP as single source of truth)
+
+```json
+{
+  "account_mapping": [
+    {
+      "username": "*oidc",
+      "password": "<oidc>#1#https://idp.example.com/realms/PIC#https://idp.example.com/realms/institution/protocol/openid-connect/certs#account#cosmohub-test#RS256#openid#asgi-webdav_",
+      "permissions": []
+    }
+  ]
+}
+```
+
+In this example:
+
+- No users are listed in `account_mapping` — the config only bootstraps the OIDC connection.
+- Every authenticated Bearer user gets their permissions exclusively from the token's `groups` claim (filtered by the `asgi-webdav_` prefix).
+- If a user's token has no matching groups, they are denied (empty `permissions` on `*oidc`).
+- This is the recommended pattern when your IdP (e.g. Keycloak) manages both identity and authorization. Group names in Keycloak should use the permission syntax directly (e.g. `asgi-webdav_+^/data/public`, `asgi-webdav_+^/data/transfer`).
+
+!!! NOTE
+
+    Two deployment patterns are supported:
+    - **Config as source of truth**: list users in `account_mapping` with explicit permissions. Token groups are ignored for known users. Simple and auditable.
+    - **IdP as source of truth**: leave `account_mapping` minimal (just the `*oidc` entry). All permissions come from the token's `groups` claim. The config never changes when users or permissions change — only the IdP does.
 
 ### How it works
 
@@ -276,8 +335,27 @@ In this example:
 2. The server verifies the JWT signature locally against the JWKS public keys (fetched at startup).
 3. The server checks the required claims: `iss`, `aud`, `azp`, `typ` ("Bearer"), `scope`, and `exp`.
 4. The `preferred_username` claim is extracted and looked up in `account_mapping`.
-5. If found, that user's permissions are used. If not found, the `*oidc` template permissions are inherited.
+5. Permissions are resolved using the priority chain below.
 6. If the token is invalid, expired, or has missing claims, the request is rejected with HTTP 401.
+
+### Permission resolution
+
+| Priority | User in `account_mapping` | Token has groups | Result | Permissions source |
+| -------- | ------------------------- | ---------------- | ------ | ------------------ |
+| 1        | Yes                       | —                | Use config | Config `permissions` (token groups ignored) |
+| 2        | No                        | Yes (matching prefix) | Use groups | Token `groups` claim, filtered by `group_prefix`, prefix stripped |
+| 3        | No                        | No / no match    | Fallback | `*oidc` template `permissions` |
+| 4        | No                        | —                | Denied  | Return `"no permission"` (no `*oidc` template configured) |
+
+**Group filtering rules:**
+
+- The `groups` claim is an array of strings in the JWT access token.
+- Only groups whose names start with `group_prefix` (the 9th field in the `<oidc>` string) are considered.
+- The prefix is stripped before use (e.g. `"asgi-webdav_+^/data/public"` becomes `"+^/data/public"`).
+- Groups without the prefix are ignored — they can coexist with unrelated Keycloak groups.
+- Empty or missing `groups` claim: treated as "no groups", falls through to `*oidc` template.
+- Empty prefix `""` means all groups are used (no filtering).
+- The IdP is trusted to provide valid permission patterns — no validation is performed on group values.
 
 ### Prerequisites
 

--- a/docs/guide/protect-your-password-in-the-config.en.md
+++ b/docs/guide/protect-your-password-in-the-config.en.md
@@ -181,12 +181,132 @@ Specify the user DN pattern, with a `username` substitution field. Example:
 
 `uid={username},cn=users,dc=ldap,dc=server,dc=com`
 
+## OIDC (OpenID Connect) Bearer Auth
+
+### username
+
+Use `"*oidc"` as `username`. This is a sentinel entry that configures the OIDC provider and serves as the default permission template for authenticated Bearer users.
+
+### password format
+
+```text
+"<oidc>#1#{issuer}#{jwks_uri}#{audience}#{client_id}#{algorithm}#{scope}"
+```
+
+### {issuer}
+
+The OIDC issuer URL. This must exactly match the `iss` claim in the JWT access token.
+
+Example:
+
+`https://idp.example.com/realms/PIC`
+
+### {jwks_uri}
+
+The JWKS (JSON Web Key Set) endpoint URL. The server fetches public keys from this endpoint at startup to verify JWT signatures locally.
+
+Example:
+
+`https://idp.example.com/realms/institution/protocol/openid-connect/certs`
+
+### {audience}
+
+The expected `aud` (audience) claim in the JWT. Must match the audience configured in your IdP for the client application.
+
+Example:
+
+`account`
+
+### {client_id}
+
+The expected `azp` (authorized party) claim in the JWT. Must match the OAuth2 client ID configured in your IdP.
+
+Example:
+
+`cosmohub-test`
+
+### {algorithm}
+
+The JWT signing algorithm used by your IdP. Must be a single algorithm (not a list).
+
+Common values: `RS256`, `ES256`
+
+### {scope}
+
+The required scope claim. The JWT's `scope` claim (space-separated) must contain this value.
+
+Example:
+
+`openid`
+
+### permissions
+
+!!! WARNING
+
+    `permissions` will be automatically applied to all OIDC Bearer users that are not explicitly listed in `account_mapping`.
+
+### Example configuration
+
+```json
+{
+  "account_mapping": [
+    {
+      "username": "*oidc",
+      "password": "<oidc>#1#https://idp.example.com/realms/PIC#https://idp.example.com/realms/institution/protocol/openid-connect/certs#account#cosmohub-test#RS256#openid",
+      "permissions": ["+^/$"]
+    },
+    {
+      "username": "alice",
+      "password": "secret",
+      "permissions": ["+^/data/public"]
+    }
+  ]
+}
+```
+
+In this example:
+
+- `*oidc` configures the OIDC provider and grants default permissions `+^/$` (root only) to any authenticated Bearer user.
+- `alice` is an explicitly configured user. When `alice` authenticates via Bearer, she gets `+^/data/public` permissions (more permissive than the default).
+- Any other Keycloak user (e.g. `bob`) who presents a valid token inherits the `*oidc` default permissions (`+^/$`).
+
+### How it works
+
+1. A client sends `Authorization: Bearer <access_token>` to the WebDAV server.
+2. The server verifies the JWT signature locally against the JWKS public keys (fetched at startup).
+3. The server checks the required claims: `iss`, `aud`, `azp`, `typ` ("Bearer"), `scope`, and `exp`.
+4. The `preferred_username` claim is extracted and looked up in `account_mapping`.
+5. If found, that user's permissions are used. If not found, the `*oidc` template permissions are inherited.
+6. If the token is invalid, expired, or has missing claims, the request is rejected with HTTP 401.
+
+### Prerequisites
+
+Install the OIDC optional dependencies:
+
+```shell
+pip install ASGIWebDAV[oidc]
+```
+
+This installs `PyJWT` and `cryptography` for JWT verification. The JWKS endpoint must be reachable from the server at startup (keys are fetched once and cached in memory).
+
+### Notes
+
+- The `*oidc` password field is parsed only during server startup. It is never used for Basic/Digest password verification — Basic auth against an OIDC-configured user always fails.
+- JWT tokens are verified locally (no network call per request). JWKS keys are fetched once at startup; restart the server to rotate keys.
+- The `preferred_username` claim is required by Keycloak. If a token is missing this claim, the request is rejected.
+- **Local verification trade-off**: access tokens are verified locally against the JWKS public keys without calling the IdP server on each request. This avoids the latency and load of per-request token introspection, but means that a token revoked at the IdP (e.g. user logout, compromised credential) will remain accepted until it naturally expires. Since access tokens are typically short-lived (5–15 minutes), this window is small and acceptable for most deployments. If immediate revocation is required, consider token introspection (not currently supported) or use shorter token lifetimes.
+
 ## Compatibility
 
-|                  | HTTP Basic auth | HTTP Digest auth |
-| ---------------- | --------------- | ---------------- |
-| Raw Mode         | Y               | Y                |
-| hashlib Mode     | Y               | N                |
-| HTTP Digest Mode | Y               | Y                |
-| LDAP(v1)         | Y               | N                |
-| LDAP(v2)         | Y               | N                |
+A single server can use **all** password modes simultaneously — each user in `account_mapping` has their own password format. The table below shows which authentication methods work with each password mode:
+
+|                  | HTTP Basic auth | HTTP Digest auth | HTTP Bearer auth |
+| ---------------- | --------------- | ---------------- | ---------------- |
+| Raw Mode         | Y               | Y                | N                |
+| hashlib Mode     | Y               | N                | N                |
+| HTTP Digest Mode | Y               | Y                | N                |
+| LDAP(v1)         | Y               | N                | N                |
+| LDAP(v2)         | Y               | N                | N                |
+| OIDC             | N               | N                | Y                |
+
+Example: a server can have `alice` with a raw password (Basic/Digest), `bob` via LDAP (Basic only), `*oidc` for Bearer auth, and an anonymous user — all at the same time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ full = { file = [
 standalone = { file = "requirements.d/standalone.txt" }
 ldap = { file = "requirements.d/ldap.txt" }
 webhdfs = { file = "requirements.d/webhdfs.txt" }
+oidc = { file = "requirements.d/oidc.txt" }
 
 [tool.pytest.ini_options]
 pythonpath = "."

--- a/requirements.d/full.txt
+++ b/requirements.d/full.txt
@@ -2,3 +2,4 @@
 -r ldap.txt
 -r standalone.txt
 -r webhdfs.txt
+-r oidc.txt

--- a/requirements.d/oidc.txt
+++ b/requirements.d/oidc.txt
@@ -1,0 +1,2 @@
+PyJWT>=2.11.0
+cryptography

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import pytest
+
+pytest.importorskip("jwt", reason="OIDC extra (PyJWT) not installed")
+pytest.importorskip("cryptography", reason="OIDC extra (cryptography) not installed")

--- a/tests/test_auth_oidc.py
+++ b/tests/test_auth_oidc.py
@@ -7,9 +7,13 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 import asgi_webdav.auth as auth_module
-from asgi_webdav.auth import DAVAuth, DAVPassword, DAVPasswordType
+from asgi_webdav.auth import DAVAuth, DAVPassword, DAVPasswordType, HTTPOIDCAuth
 from asgi_webdav.config import generate_config_from_dict
-from asgi_webdav.exceptions import DAVExceptionAuthFailed
+from asgi_webdav.exceptions import (
+    DAVExceptionAuthFailed,
+    DAVExceptionConfig,
+    DAVExceptionProviderInitFailed,
+)
 
 from .testkit_asgi import create_dav_request_object
 
@@ -245,3 +249,87 @@ def test_dav_auth_create_response_401_includes_bearer(oidc_dav_auth):
     challenge = response.headers.get(b"WWW-Authenticate")
     assert challenge.startswith(b"Basic")
     assert challenge.endswith(b"Bearer")
+
+
+def test_http_oidc_auth_init_jwt_not_installed():
+    with (
+        patch.object(auth_module, "jwt", None),
+        patch.object(auth_module, "PyJWKClient", None),
+    ):
+        with pytest.raises(DAVExceptionConfig, match="install OIDC module"):
+            HTTPOIDCAuth(OIDC_PASSWORD.split("#"))
+
+
+def test_http_oidc_auth_init_unsupported_version():
+    bad_password = ("<oidc>#99#issuer#jwks_uri#audience#client_id#RS256#openid").split(
+        "#"
+    )
+    with patch.object(auth_module, "PyJWKClient") as mock_pjwk:
+        mock_pjwk.return_value.get_jwk_set = MagicMock()
+        with pytest.raises(
+            DAVExceptionConfig, match="Unsupported OIDC password version"
+        ):
+            HTTPOIDCAuth(bad_password)
+
+
+def test_http_oidc_auth_init_jwks_fetch_failure():
+    password_data = OIDC_PASSWORD.split("#")
+    with patch.object(auth_module, "PyJWKClient") as mock_pjwk:
+        mock_pjwk.return_value.get_jwk_set.side_effect = ConnectionError(
+            "network error"
+        )
+        with pytest.raises(
+            DAVExceptionProviderInitFailed, match="Failed to fetch JWKS"
+        ):
+            HTTPOIDCAuth(password_data)
+
+
+def test_http_oidc_auth_verify_token_jwt_library_none(rsa_keys, oidc_dav_auth):
+    with patch.object(auth_module, "jwt", None):
+        with pytest.raises(DAVExceptionAuthFailed):
+            oidc_dav_auth.oidc_auth.verify_token("fake.token.value")
+
+
+async def test_dav_auth_init_oidc_wrong_password_format():
+    config = generate_config_from_dict(
+        {
+            "account_mapping": [
+                {
+                    "username": "*oidc",
+                    "password": "plain-text-password",
+                    "permissions": ["+"],
+                }
+            ],
+            "provider_mapping": [{"prefix": "/", "uri": "memory:///"}],
+        },
+        complete_config=True,
+    )
+    with pytest.raises(DAVExceptionConfig, match="must use the <oidc> format"):
+        DAVAuth(config)
+
+
+async def test_dav_auth_pick_out_user_bearer_unknown_user_no_fallback(rsa_keys):
+    private_key, _ = rsa_keys
+    config = generate_config_from_dict(
+        {
+            "account_mapping": [
+                {"username": "alice", "password": "secret", "permissions": ["+"]}
+            ],
+            "provider_mapping": [{"prefix": "/", "uri": "memory:///"}],
+        },
+        complete_config=True,
+    )
+    with patch.object(auth_module, "PyJWKClient") as mock_pjwk:
+        mock_client = MagicMock()
+        mock_client.get_jwk_set = MagicMock()
+        mock_client.get_signing_key_from_jwt = MagicMock(
+            return_value=SimpleNamespace(key=rsa_keys[1])
+        )
+        mock_pjwk.return_value = mock_client
+        dav_auth = DAVAuth(config)
+        dav_auth.oidc_auth = HTTPOIDCAuth(OIDC_PASSWORD.split("#"))
+
+    token = _make_token(private_key, preferred_username="unknown-user")
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message == "no permission"

--- a/tests/test_auth_oidc.py
+++ b/tests/test_auth_oidc.py
@@ -1,0 +1,247 @@
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import asgi_webdav.auth as auth_module
+from asgi_webdav.auth import DAVAuth, DAVPassword, DAVPasswordType
+from asgi_webdav.config import generate_config_from_dict
+from asgi_webdav.exceptions import DAVExceptionAuthFailed
+
+from .testkit_asgi import create_dav_request_object
+
+OIDC_PASSWORD = (
+    "<oidc>#1"
+    "#https://idp.example.com/realms/PIC"
+    "#https://idp.example.com/realms/PIC/protocol/openid-connect/certs"
+    "#account"
+    "#cosmohub-test"
+    "#RS256"
+    "#openid"
+)
+
+ISSUER = "https://idp.example.com/realms/PIC"
+AUDIENCE = "account"
+CLIENT_ID = "cosmohub-test"
+
+
+@pytest.fixture
+def rsa_keys():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    return private_key, public_key
+
+
+def _make_token(private_key, **overrides) -> str:
+    payload = {
+        "preferred_username": "bob",
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "azp": CLIENT_ID,
+        "typ": "Bearer",
+        "scope": "openid profile",
+        "exp": int(time.time()) + 3600,
+    }
+    payload.update(overrides)
+    return jwt.encode(payload, private_key, algorithm="RS256")
+
+
+def _build_oidc_dav_auth(rsa_keys, account_mapping):
+    private_key, public_key = rsa_keys
+    config = generate_config_from_dict(
+        {
+            "account_mapping": account_mapping,
+            "provider_mapping": [{"prefix": "/", "uri": "memory:///"}],
+        },
+        complete_config=True,
+    )
+    with patch.object(auth_module, "PyJWKClient") as mock_pjwk:
+        mock_client = MagicMock()
+        mock_client.get_jwk_set = MagicMock()
+        mock_client.get_signing_key_from_jwt = MagicMock(
+            return_value=SimpleNamespace(key=public_key)
+        )
+        mock_pjwk.return_value = mock_client
+        dav_auth = DAVAuth(config)
+    return dav_auth
+
+
+@pytest.fixture
+def oidc_dav_auth(rsa_keys):
+    account_mapping = [
+        {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]},
+        {
+            "username": "alice",
+            "password": "secret",
+            "permissions": ["+^/data/public"],
+        },
+    ]
+    yield _build_oidc_dav_auth(rsa_keys, account_mapping)
+
+
+def test_dav_password_oidc_parsing():
+    pw = DAVPassword(OIDC_PASSWORD)
+    assert pw.type == DAVPasswordType.OIDC
+    assert len(pw.data) == 8
+    assert pw.data[2] == ISSUER
+    assert pw.data[3].endswith("/certs")
+    assert pw.data[4] == AUDIENCE
+    assert pw.data[5] == CLIENT_ID
+    assert pw.data[6] == "RS256"
+    assert pw.data[7] == "openid"
+
+    # wrong field count -> INVALID (Bearer-only requires the 8-field form)
+    bad = DAVPassword("<oidc>#1#issuer#jwks#aud#cid#RS256")
+    assert bad.type == DAVPasswordType.INVALID
+
+
+def test_http_oidc_auth_verify_token_valid(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key)
+    payload = oidc_dav_auth.oidc_auth.verify_token(token)
+    assert payload["preferred_username"] == "bob"
+
+
+def test_http_oidc_auth_verify_token_wrong_iss(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, iss="https://evil.example.com")
+    with pytest.raises(DAVExceptionAuthFailed):
+        oidc_dav_auth.oidc_auth.verify_token(token)
+
+
+def test_http_oidc_auth_verify_token_wrong_aud(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, aud="other-audience")
+    with pytest.raises(DAVExceptionAuthFailed):
+        oidc_dav_auth.oidc_auth.verify_token(token)
+
+
+def test_http_oidc_auth_verify_token_wrong_azp(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, azp="other-client")
+    with pytest.raises(DAVExceptionAuthFailed):
+        oidc_dav_auth.oidc_auth.verify_token(token)
+
+
+def test_http_oidc_auth_verify_token_wrong_typ(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, typ="ID")
+    with pytest.raises(DAVExceptionAuthFailed):
+        oidc_dav_auth.oidc_auth.verify_token(token)
+
+
+def test_http_oidc_auth_verify_token_missing_scope(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, scope="email")
+    with pytest.raises(DAVExceptionAuthFailed):
+        oidc_dav_auth.oidc_auth.verify_token(token)
+
+
+def test_http_oidc_auth_verify_token_expired(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, exp=int(time.time()) - 10)
+    with pytest.raises(DAVExceptionAuthFailed):
+        oidc_dav_auth.oidc_auth.verify_token(token)
+
+
+async def test_dav_auth_pick_out_user_bearer_valid_user(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, preferred_username="alice")
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await oidc_dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.username == "alice"
+    assert request.authorization_method == "Bearer"
+
+
+async def test_dav_auth_pick_out_user_bearer_fallback(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    # "bob" is not in account_mapping -> inherits *oidc template permissions
+    token = _make_token(private_key, preferred_username="bob")
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await oidc_dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.username == "bob"
+    assert request.user.permissions == ["+"]
+
+
+async def test_dav_auth_pick_out_user_bearer_invalid(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    token = _make_token(private_key, exp=int(time.time()) - 10)
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await oidc_dav_auth.pick_out_user(request)
+    assert message == "no permission"
+
+
+async def test_dav_auth_pick_out_user_bearer_missing_username(rsa_keys, oidc_dav_auth):
+    private_key, _ = rsa_keys
+    payload = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "azp": CLIENT_ID,
+        "typ": "Bearer",
+        "scope": "openid",
+        "exp": int(time.time()) + 3600,
+    }
+    token = jwt.encode(payload, private_key, algorithm="RS256")
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await oidc_dav_auth.pick_out_user(request)
+    assert message == "no permission"
+
+
+async def test_dav_auth_pick_out_user_bearer_not_configured(rsa_keys):
+    private_key, _ = rsa_keys
+    config = generate_config_from_dict(
+        {
+            "account_mapping": [
+                {"username": "alice", "password": "secret", "permissions": ["+"]}
+            ],
+            "provider_mapping": [{"prefix": "/", "uri": "memory:///"}],
+        },
+        complete_config=True,
+    )
+    dav_auth = DAVAuth(config)
+    token = _make_token(private_key, preferred_username="alice")
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message == "OpenID not available"
+
+
+async def test_dav_auth_pick_out_user_bearer_invalid_no_anonymous_fallback(rsa_keys):
+    private_key, _ = rsa_keys
+    config = generate_config_from_dict(
+        {
+            "account_mapping": [
+                {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]}
+            ],
+            "anonymous": {"enable": True},
+            "provider_mapping": [{"prefix": "/", "uri": "memory:///"}],
+        },
+        complete_config=True,
+    )
+    with patch.object(auth_module, "PyJWKClient") as mock_pjwk:
+        mock_client = MagicMock()
+        mock_client.get_jwk_set = MagicMock()
+        mock_client.get_signing_key_from_jwt = MagicMock(
+            return_value=SimpleNamespace(key=rsa_keys[1])
+        )
+        mock_pjwk.return_value = mock_client
+        dav_auth = DAVAuth(config)
+    token = _make_token(private_key, exp=int(time.time()) - 10)
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    # invalid Bearer must hard-fail (401), never silently degrade to anonymous
+    assert message is not None
+
+
+def test_dav_auth_create_response_401_includes_bearer(oidc_dav_auth):
+    request = create_dav_request_object()
+    oidc_dav_auth.config.http_digest_auth.enable = False
+    oidc_dav_auth.config.http_digest_auth.enable_rule = ""
+    response = oidc_dav_auth.create_response_401(request, "msg")
+    challenge = response.headers.get(b"WWW-Authenticate")
+    assert challenge.startswith(b"Basic")
+    assert challenge.endswith(b"Bearer")

--- a/tests/test_auth_oidc.py
+++ b/tests/test_auth_oidc.py
@@ -25,6 +25,7 @@ OIDC_PASSWORD = (
     "#cosmohub-test"
     "#RS256"
     "#openid"
+    "#asgi-webdav_"
 )
 
 ISSUER = "https://idp.example.com/realms/PIC"
@@ -89,15 +90,16 @@ def oidc_dav_auth(rsa_keys):
 def test_dav_password_oidc_parsing():
     pw = DAVPassword(OIDC_PASSWORD)
     assert pw.type == DAVPasswordType.OIDC
-    assert len(pw.data) == 8
+    assert len(pw.data) == 9
     assert pw.data[2] == ISSUER
     assert pw.data[3].endswith("/certs")
     assert pw.data[4] == AUDIENCE
     assert pw.data[5] == CLIENT_ID
     assert pw.data[6] == "RS256"
     assert pw.data[7] == "openid"
+    assert pw.data[8] == "asgi-webdav_"
 
-    # wrong field count -> INVALID (Bearer-only requires the 8-field form)
+    # wrong field count -> INVALID (requires the 9-field form)
     bad = DAVPassword("<oidc>#1#issuer#jwks#aud#cid#RS256")
     assert bad.type == DAVPasswordType.INVALID
 
@@ -333,3 +335,129 @@ async def test_dav_auth_pick_out_user_bearer_unknown_user_no_fallback(rsa_keys):
     request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
     message = await dav_auth.pick_out_user(request)
     assert message == "no permission"
+
+
+# --- Groups-based permission tests ---
+
+
+async def test_dav_auth_pick_out_user_bearer_groups_used(rsa_keys):
+    """User not in config, token has groups → use groups as permissions."""
+    private_key, _ = rsa_keys
+    account_mapping = [
+        {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]},
+    ]
+    dav_auth = _build_oidc_dav_auth(rsa_keys, account_mapping)
+
+    token = _make_token(
+        private_key,
+        preferred_username="charlie",
+        groups=["asgi-webdav_+^/data/transfer", "asgi-webdav_+^/data/public"],
+    )
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.username == "charlie"
+    assert request.user.permissions == ["+^/data/transfer", "+^/data/public"]
+
+
+async def test_dav_auth_pick_out_user_bearer_config_wins_over_groups(rsa_keys):
+    """User in config and token has groups → config permissions used, groups ignored."""
+    private_key, _ = rsa_keys
+    account_mapping = [
+        {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]},
+        {
+            "username": "alice",
+            "password": "secret",
+            "permissions": ["+^/data/public"],
+        },
+    ]
+    dav_auth = _build_oidc_dav_auth(rsa_keys, account_mapping)
+
+    token = _make_token(
+        private_key,
+        preferred_username="alice",
+        groups=["asgi-webdav_+^/data/transfer"],
+    )
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.permissions == ["+^/data/public"]
+
+
+async def test_dav_auth_pick_out_user_bearer_empty_groups_fallback(rsa_keys):
+    """User not in config, token has empty groups → fall back to *oidc template."""
+    private_key, _ = rsa_keys
+    account_mapping = [
+        {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]},
+    ]
+    dav_auth = _build_oidc_dav_auth(rsa_keys, account_mapping)
+
+    token = _make_token(
+        private_key,
+        preferred_username="dave",
+        groups=[],
+    )
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.username == "dave"
+    assert request.user.permissions == ["+"]
+
+
+async def test_dav_auth_pick_out_user_bearer_no_groups_claim_fallback(rsa_keys):
+    """User not in config, token has no groups claim → fall back to *oidc template."""
+    private_key, _ = rsa_keys
+    account_mapping = [
+        {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]},
+    ]
+    dav_auth = _build_oidc_dav_auth(rsa_keys, account_mapping)
+
+    token = _make_token(private_key, preferred_username="eve")
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.username == "eve"
+    assert request.user.permissions == ["+"]
+
+
+async def test_dav_auth_pick_out_user_bearer_groups_prefix_filtered(rsa_keys):
+    """Only groups matching the prefix are used; others are ignored."""
+    private_key, _ = rsa_keys
+    account_mapping = [
+        {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]},
+    ]
+    dav_auth = _build_oidc_dav_auth(rsa_keys, account_mapping)
+
+    token = _make_token(
+        private_key,
+        preferred_username="frank",
+        groups=[
+            "asgi-webdav_+^/data/transfer",
+            "other-app_admin",
+            "asgi-webdav_+^/data/public",
+        ],
+    )
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.permissions == ["+^/data/transfer", "+^/data/public"]
+
+
+async def test_dav_auth_pick_out_user_bearer_no_matching_prefix_fallback(rsa_keys):
+    """Token has groups but none match prefix → fall back to *oidc template."""
+    private_key, _ = rsa_keys
+    account_mapping = [
+        {"username": "*oidc", "password": OIDC_PASSWORD, "permissions": ["+"]},
+    ]
+    dav_auth = _build_oidc_dav_auth(rsa_keys, account_mapping)
+
+    token = _make_token(
+        private_key,
+        preferred_username="grace",
+        groups=["other-app_admin", "unrelated_reader"],
+    )
+    request = create_dav_request_object(headers={"authorization": f"Bearer {token}"})
+    message = await dav_auth.pick_out_user(request)
+    assert message is None
+    assert request.user.username == "grace"
+    assert request.user.permissions == ["+"]


### PR DESCRIPTION
# OIDC Bearer Token Authentication
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/ASGI-WebDAV/ASGI-WebDAV/blob/main/CONTRIBUTING.md)
- [x] One Feature(issue) One PR
- [x] All commits in the PR will be merged into a single commit.
- [x] Add an entry in `changelog.en.md` if necessary? Don't forget to add your name and github profile link!
- [x] Add / update tests if necessary, Don't missing.
- [x] Add new / update outdated documentation

# Description

Add HTTP Bearer token authentication using OpenID Connect (OIDC). When a client sends `Authorization: Bearer <access_token>`, the server verifies the JWT locally against the IdP's JWKS public keys (fetched at startup, no per-request network call), validates required claims (`iss`, `aud`, `azp`, `typ`, `scope`, `exp`), extracts `preferred_username`, and resolves permissions from `account_mapping`.

## What's new

- **`HTTPOIDCAuth` class** (`asgi_webdav/auth.py`) — verifies JWTs locally against JWKS public keys. Eagerly fetches keys at startup; failure is fatal.
- **`DAVPasswordType.OIDC`** — new password type with format `<oidc>#1#issuer#jwks_uri#audience#client_id#algorithm#scope`.
- **`*oidc` sentinel user** — mirrors the `*ldap` convention. Configures the OIDC provider and serves as the default permission template for authenticated Bearer users not explicitly listed in `account_mapping`.
- **Bearer auth in `DAVAuth.pick_out_user()`** — handles `Authorization: Bearer` header, verifies token, looks up user permissions, falls back to `*oidc` template.
- **`WWW-Authenticate: Bearer`** appended to 401 challenge when OIDC is configured.

## Configuration

Add a `*oidc` entry to `account_mapping`:

```json
{
  "account_mapping": [
    {
      "username": "*oidc",
      "password": "<oidc>#1#https://idp.example.com/realms/PIC#https://idp.example.com/realms/PIC/protocol/openid-connect/certs#account#cosmohub-test#RS256#openid",
      "permissions": ["+^/$"]
    }
  ]
}
```

Install the optional dependency: `pip install ASGIWebDAV[oidc]`

## Key design decisions

- **Local verification** — JWTs are verified against JWKS public keys without calling the IdP per request. Revoked tokens remain valid until expiry (typically 5-15 min). This avoids IdP latency and load.
- **Fallback behavior** — Unknown Bearer users inherit `*oidc` template permissions. Invalid Bearer tokens always return 401 (never degrade to anonymous).
- **Basic auth rejection** — Basic auth against an OIDC-configured user explicitly fails; the `*oidc` password field is only used for JWT configuration.
- **Optional dependency** — PyJWT + cryptography are in a separate `[oidc]` extra to avoid bloating the core install.

## Files changed

| File | Change |
|------|--------|
| `asgi_webdav/auth.py` | `HTTPOIDCAuth` class, `DAVPasswordType.OIDC`, Bearer handling in `pick_out_user()` and `create_response_401()` |
| `requirements.d/oidc.txt` | New — `PyJWT>=2.11.0`, `cryptography` |
| `requirements.d/full.txt` | Added `-r oidc.txt` |
| `pyproject.toml` | Added `[oidc]` extra |
| `tests/conftest.py` | Skip tests if PyJWT not installed |
| `tests/test_auth_oidc.py` | 247-line test suite — token parsing, claim verification, user lookup, fallback, edge cases |
| `docs/guide/authentication.en.md` | Updated auth flow diagram, added Bearer auth section |
| `docs/guide/protect-your-password-in-the-config.en.md` | Full OIDC configuration reference, compatibility table |
| `docs/changelog.en.md` | v2.1.0 entry |

fixes #95 

<!--
Verified locally with:
- `pre-commit run -a` — all checks pass
- `mypy` — strict mode, no errors
- `pytest tests/test_auth_oidc.py` — 14 tests pass
-->
