### PR TITLE
fix: catch httpx transport errors in WebHDFS provider

### DIFF
--- a/asgi_webdav/provider/webhdfs.py
+++ b/asgi_webdav/provider/webhdfs.py
@@ -90,7 +90,7 @@ class WebHDFSProvider(DAVProvider):
             response.raise_for_status()
             data = response.json()
 
-        except httpx.HTTPStatusError:
+        except httpx.HTTPError:
             logger.exception("Exception in get dav property d1 infinity.")
             return
 
@@ -204,7 +204,8 @@ class WebHDFSProvider(DAVProvider):
 
             return dav_properties
 
-        except httpx.HTTPStatusError:
+        except httpx.HTTPError:
+            logger.exception("Exception in do propfind.")
             return dav_properties
 
     async def _do_proppatch(self, request: DAVRequest) -> int:
@@ -243,8 +244,11 @@ class WebHDFSProvider(DAVProvider):
             response.raise_for_status()
             return 201
 
-        except httpx.HTTPStatusError as error:
-            return error.response.status_code
+        except httpx.HTTPError as error:
+            logger.exception("Exception in do mkcol.")
+            if isinstance(error, httpx.HTTPStatusError):
+                return error.response.status_code
+            return 500
 
     async def _do_get(self, request: DAVRequest) -> tuple[
         int,
@@ -292,8 +296,11 @@ class WebHDFSProvider(DAVProvider):
                 response_content_range,
             )
 
-        except httpx.HTTPStatusError as error:
-            return error.response.status_code, None, None, None
+        except httpx.HTTPError as error:
+            logger.exception("Exception in do get.")
+            if isinstance(error, httpx.HTTPStatusError):
+                return error.response.status_code, None, None, None
+            return 500, None, None, None
 
     async def _dav_response_data_generator(
         self,
@@ -335,8 +342,11 @@ class WebHDFSProvider(DAVProvider):
             )
             return 200, dav_property.basic_data
 
-        except httpx.HTTPStatusError as error:
-            return error.response.status_code, None
+        except httpx.HTTPError as error:
+            logger.exception("Exception in do head.")
+            if isinstance(error, httpx.HTTPStatusError):
+                return error.response.status_code, None
+            return 500, None
 
     async def _do_delete(self, request: DAVRequest) -> int:
         parent_exists, file_exists, is_collection = await self._precheck_source(request)
@@ -353,7 +363,8 @@ class WebHDFSProvider(DAVProvider):
             response.raise_for_status()
             return 204
 
-        except httpx.HTTPStatusError:
+        except httpx.HTTPError:
+            logger.exception("Exception in do delete.")
             return 424
 
     async def _do_put(self, request: DAVRequest) -> int:
@@ -382,8 +393,11 @@ class WebHDFSProvider(DAVProvider):
                 return 204
             return 201
 
-        except httpx.HTTPStatusError as error:
-            return error.response.status_code
+        except httpx.HTTPError as error:
+            logger.exception("Exception in do put.")
+            if isinstance(error, httpx.HTTPStatusError):
+                return error.response.status_code
+            return 500
 
     async def _get_res_etag(self, request: DAVRequest) -> str:
         url_path = self._get_url_path(request.dist_src_path, request.user.username)
@@ -417,8 +431,9 @@ class WebHDFSProvider(DAVProvider):
             try:
                 response = await self.client.delete(actual_url)
                 response.raise_for_status()
-            except httpx.HTTPStatusError:
+            except httpx.HTTPError:
                 # Not able to overwrite
+                logger.exception("Exception in do move.")
                 return 403
 
         src_path = self._get_url_path(request.dist_src_path, request.user.username)
@@ -436,8 +451,11 @@ class WebHDFSProvider(DAVProvider):
                 return 204
             return 201
 
-        except httpx.HTTPStatusError as error:
-            return error.response.status_code
+        except httpx.HTTPError as error:
+            logger.exception("Exception in do move.")
+            if isinstance(error, httpx.HTTPStatusError):
+                return error.response.status_code
+            return 500
 
     async def _precheck_source(self, request: DAVRequest) -> tuple[bool, bool, bool]:
         parent_exists = True

--- a/tests/test_provider_webhdfs.py
+++ b/tests/test_provider_webhdfs.py
@@ -429,9 +429,6 @@ async def test_do_propfind(mock_provider, fake_request):
     mock_provider.client.get.return_value = mock_response
 
     response = await mock_provider._do_propfind(fake_request)
-    from icecream import ic
-
-    ic(response)
 
     expected = {
         DAVPath("/testfile.txt"): DAVProperty(
@@ -546,6 +543,208 @@ async def test_do_move_destination_exists_no_overwrite(mock_provider, fake_reque
     fake_request.overwrite = False
 
     mock_provider._precheck_destination = AsyncMock(return_value=(True, True, True))
+
+    result = await mock_provider._do_move(fake_request)
+
+    assert result == 403
+
+
+@pytest.mark.asyncio
+async def test_get_dav_property_d1_infinity_http_error(mock_provider, fake_request):
+    mock_provider.client.get = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    dav_properties = {}
+    result = await mock_provider._get_dav_property_d1_infinity(
+        dav_properties=dav_properties,
+        request=fake_request,
+        url_path=DAVPath("/folder"),
+        infinity=False,
+    )
+
+    assert result is None
+    assert dav_properties == {}
+
+
+@pytest.mark.asyncio
+async def test_do_propfind_http_error(mock_provider, fake_request):
+    mock_provider.client.get = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    result = await mock_provider._do_propfind(fake_request)
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_do_delete_transport_error(mock_provider, fake_request):
+    mock_provider._precheck_source = AsyncMock(return_value=(True, True, False))
+    mock_provider.client.delete = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    result = await mock_provider._do_delete(fake_request)
+
+    assert result == 424
+
+
+@pytest.mark.asyncio
+async def test_do_mkcol_http_status_error(mock_provider, fake_request):
+    fake_request.body_is_parsed_success = False
+    mock_provider._precheck_source = AsyncMock(return_value=(True, False, False))
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock(status_code=403)
+        )
+    )
+    mock_provider.client.put = AsyncMock(return_value=mock_response)
+
+    result = await mock_provider._do_mkcol(fake_request)
+
+    assert result == 403
+
+
+@pytest.mark.asyncio
+async def test_do_mkcol_transport_error(mock_provider, fake_request):
+    fake_request.body_is_parsed_success = False
+    mock_provider._precheck_source = AsyncMock(return_value=(True, False, False))
+    mock_provider.client.put = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    result = await mock_provider._do_mkcol(fake_request)
+
+    assert result == 500
+
+
+@pytest.mark.asyncio
+async def test_do_get_http_status_error(mock_provider, fake_request):
+    mock_provider._get_dav_property_d0 = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock(status_code=404)
+        )
+    )
+
+    status, basic_data, generator, content_range = await mock_provider._do_get(
+        fake_request
+    )
+
+    assert status == 404
+    assert basic_data is None
+    assert generator is None
+    assert content_range is None
+
+
+@pytest.mark.asyncio
+async def test_do_get_transport_error(mock_provider, fake_request):
+    mock_provider._get_dav_property_d0 = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    status, basic_data, generator, content_range = await mock_provider._do_get(
+        fake_request
+    )
+
+    assert status == 500
+    assert basic_data is None
+    assert generator is None
+    assert content_range is None
+
+
+@pytest.mark.asyncio
+async def test_do_head_http_status_error(mock_provider, fake_request):
+    mock_provider._get_dav_property_d0 = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock(status_code=404)
+        )
+    )
+
+    status, basic_data = await mock_provider._do_head(fake_request)
+
+    assert status == 404
+    assert basic_data is None
+
+
+@pytest.mark.asyncio
+async def test_do_head_transport_error(mock_provider, fake_request):
+    mock_provider._get_dav_property_d0 = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    status, basic_data = await mock_provider._do_head(fake_request)
+
+    assert status == 500
+    assert basic_data is None
+
+
+@pytest.mark.asyncio
+async def test_do_put_http_status_error(mock_provider, fake_request):
+    mock_provider._precheck_source = AsyncMock(return_value=(True, False, False))
+    mock_provider.client.put = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock(status_code=409)
+        )
+    )
+
+    result = await mock_provider._do_put(fake_request)
+
+    assert result == 409
+
+
+@pytest.mark.asyncio
+async def test_do_put_transport_error(mock_provider, fake_request):
+    mock_provider._precheck_source = AsyncMock(return_value=(True, False, False))
+    mock_provider.client.put = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    result = await mock_provider._do_put(fake_request)
+
+    assert result == 500
+
+
+@pytest.mark.asyncio
+async def test_do_move_http_status_error(mock_provider, fake_request):
+    fake_request.overwrite = True
+    mock_provider._precheck_destination = AsyncMock(return_value=(True, False, False))
+
+    mock_provider.client.put = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=MagicMock(status_code=409)
+        )
+    )
+
+    result = await mock_provider._do_move(fake_request)
+
+    assert result == 409
+
+
+@pytest.mark.asyncio
+async def test_do_move_transport_error(mock_provider, fake_request):
+    fake_request.overwrite = True
+    mock_provider._precheck_destination = AsyncMock(return_value=(True, False, False))
+
+    mock_provider.client.put = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
+
+    result = await mock_provider._do_move(fake_request)
+
+    assert result == 500
+
+
+@pytest.mark.asyncio
+async def test_do_move_overwrite_delete_fails(mock_provider, fake_request):
+    fake_request.overwrite = True
+    mock_provider._precheck_destination = AsyncMock(return_value=(True, False, True))
+
+    mock_provider.client.delete = AsyncMock(
+        side_effect=httpx.ConnectError("connection failed")
+    )
 
     result = await mock_provider._do_move(fake_request)
 


### PR DESCRIPTION
# Description

All exception handlers in `webhdfs.py` only caught `httpx.HTTPStatusError`, which does not cover transport-level exceptions such as `PoolTimeout`, `ConnectError`, and other `httpx.RequestError` exceptions.

When the HDFS backend is slow or unreachable, these exceptions could propagate as unhandled exceptions and result in generic HTTP 500 responses.

This PR updates the WebHDFS provider to catch transport-level `httpx` errors and handle them consistently with other HTTP errors.

fixes #97

## Checklist

* [X] I have read the [[contribution guidelines](https://github.com/ASGI-WebDAV/ASGI-WebDAV/blob/main/CONTRIBUTING.md)](https://github.com/ASGI-WebDAV/ASGI-WebDAV/blob/main/CONTRIBUTING.md)
* [X] One Feature(issue) One PR
* [X] All commits in the PR will be merged into a single commit.
* [X] Add an entry in `changelog.en.md` if necessary? Don't forget to add your name and GitHub profile link!
* [X] Add / update tests if necessary.
* [X] Add new / update outdated documentation